### PR TITLE
Fixing the typo OCB -> OCP in the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PIQE Test Libraries - PIQE OCB Library
+# PIQE Test Libraries - PIQE OCP Library
 
 **This is a work in progress and not recommended for consumption at this point.**
 


### PR DESCRIPTION
Signed-off-by: ShwethaHP <spandura@redhat.com>