### PR TITLE
[CSSWA-454] Flake8 fix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,12 +1,12 @@
-pipeline { 
+pipeline {
     agent { label 'master' }
     environment {
         KUBECONFIG = credentials('a700aafc-b29c-4052-a8f8-c93863709f25')
         PATH = "/usr/local/bin:$PATH"
-    }    
+    }
     stages {
-        stage('Setup') { 
-            steps { 
+        stage('Setup') {
+            steps {
                 sh '''#!/bin/bash -ex
                     python3 -m venv scenario
                     source scenario/bin/activate
@@ -18,16 +18,16 @@ pipeline {
                 '''
             }
         }
-        stage('Flake8') { 
-            steps { 
+        stage('Flake8') {
+            steps {
                 sh '''#!/bin/bash -ex
                     source scenario/bin/activate
-                    find . -name *.py | grep -v 'doc' | xargs -i flake8 {}  --show-source --max-line-length=120
+                    flake8 piqe_ocp_lib/* --show-source --max-line-length=120 --ignore E731
                 '''
             }
-        }         
+        }
         stage('PyTest') {
-            steps { 
+            steps {
                 sh '''#!/bin/bash -ex
                     source scenario/bin/activate
                     pytest -sv piqe_ocp_lib/tests/resources

--- a/piqe_ocp_lib/api/crd/ocp_pipeline_runs.py
+++ b/piqe_ocp_lib/api/crd/ocp_pipeline_runs.py
@@ -228,6 +228,6 @@ class OcpPipelineRuns(OcpBase):
                     logger.info("Pipeline Run %s is in %s state", pipeline_run_name, pipeline_run_condition["status"])
                     pipeline_run_ready = True
                     return pipeline_run_ready
-        logger.error(f"Pipeline Run %s is in %s state. Message : %s",
+        logger.error("Pipeline Run %s is in %s state. Message : %s",
                      pipeline_run_name, pipeline_run_condition["status"], pipeline_run_condition["message"])
         return pipeline_run_ready

--- a/piqe_ocp_lib/api/monitoring/ocp_prometheus_client.py
+++ b/piqe_ocp_lib/api/monitoring/ocp_prometheus_client.py
@@ -108,7 +108,7 @@ class OcpPrometheusClient(OcpBase):
                 # Suppress only the single warning from urllib3 needed.
                 requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
                 prometheus_api_response = requests.get(final_prometheus_url, headers=headers, verify=False)
-        except (ConnectionError, HTTPError, RequestException) as e:
+        except (ConnectionError, HTTPError, RequestException):
             logger.exception("Failed to connect %s due to refused connection or unsuccessful status code",
                              final_prometheus_url)
 

--- a/piqe_ocp_lib/api/resources/ocp_apps.py
+++ b/piqe_ocp_lib/api/resources/ocp_apps.py
@@ -59,7 +59,7 @@ class OcpApps(OcpBase):
                 api_response_list.append(api_response)
             except ApiException as e:
                 logger.error("Exception when calling method: "
-                             " create_app_from_template_" + str(resource['kind']).lower()+"%s\n", e)
+                             " create_app_from_template_" + str(resource['kind']).lower() + "%s\n", e)
         return api_response_list, deployment_config_names
 
     def delete_template_based_app(self, project, template_name, ident, app_params, template_location='openshift'):
@@ -93,5 +93,5 @@ class OcpApps(OcpBase):
                 api_response_list.append(api_response)
             except ApiException as e:
                 logger.error("Exception when calling method: "
-                             " delete_template_based_app_" + str(resource['kind']).lower()+"%s\n", e)
+                             " delete_template_based_app_" + str(resource['kind']).lower() + "%s\n", e)
         return api_response_list

--- a/piqe_ocp_lib/api/resources/ocp_configs.py
+++ b/piqe_ocp_lib/api/resources/ocp_configs.py
@@ -16,7 +16,7 @@ class OcpConfig(OcpBase):
         :return: None
         """
 
-    def __init__(self,  kind, api_version, kube_config_file=None):
+    def __init__(self, kind, api_version, kube_config_file=None):
         super(OcpConfig, self).__init__(kube_config_file=kube_config_file)
         self.kube_config_file = kube_config_file
         self.ocp_config = self.dyn_client.resources.get(api_version=api_version, kind=kind)

--- a/piqe_ocp_lib/api/resources/ocp_limit_ranges.py
+++ b/piqe_ocp_lib/api/resources/ocp_limit_ranges.py
@@ -253,7 +253,7 @@ class OcpLimitRangeItem(object):
     """
 
     def __init__(self, type):
-    
+
         self._model = V1LimitRangeItem(type=type)
 
     def type(self) -> str:
@@ -261,7 +261,7 @@ class OcpLimitRangeItem(object):
        This returns the type of V1LimitRangeItem builder.
        :return: V1LimitRangeItem type
        """
-    
+
         return self._model.type
 
     def _set_properties(self, type: str, min: Union[str, None] = None, max: Union[str, None] = None,
@@ -291,7 +291,7 @@ class OcpLimitRangeItem(object):
                 self._model.max.update({type: max})
         if default:
             if self._model.default is None:
-                 self._model.default = {type: default}
+                self._model.default = {type: default}
             else:
                 self._model.default.update({type: default})
         if default_request:

--- a/piqe_ocp_lib/api/resources/ocp_nodes.py
+++ b/piqe_ocp_lib/api/resources/ocp_nodes.py
@@ -74,9 +74,9 @@ class OcpNodes(OcpBase):
                 if node["status"]["capacity"]["memory"][-2:] == "Ki":
                     total_memory_in_bytes += int(node["status"]["capacity"]["memory"][:-2]) * 1024
                 if node["status"]["capacity"]["memory"][-2:] == "Mi":
-                    total_memory_in_bytes += int(node["status"]["capacity"]["memory"][:-2]) * (1024*1024)
+                    total_memory_in_bytes += int(node["status"]["capacity"]["memory"][:-2]) * (1024 * 1024)
                 if node["status"]["capacity"]["memory"][-2:] == "Gi":
-                    total_memory_in_bytes += int(node["status"]["capacity"]["memory"][:-2]) * (1024*1024)
+                    total_memory_in_bytes += int(node["status"]["capacity"]["memory"][:-2]) * (1024 * 1024)
             logger.info("Total memory in bytes : %s", total_memory_in_bytes)
         return total_memory_in_bytes
 

--- a/piqe_ocp_lib/api/resources/ocp_operators.py
+++ b/piqe_ocp_lib/api/resources/ocp_operators.py
@@ -3,7 +3,6 @@ from kubernetes.client.rest import ApiException
 import logging
 from piqe_ocp_lib import __loggername__
 from time import sleep
-from pprint import pprint
 
 logger = logging.getLogger(__loggername__)
 

--- a/piqe_ocp_lib/api/tasks/operator_ops.py
+++ b/piqe_ocp_lib/api/tasks/operator_ops.py
@@ -1,7 +1,6 @@
 from piqe_ocp_lib.api.resources import OcpBase, OcpProjects
 from piqe_ocp_lib.api.resources.ocp_operators import OperatorhubPackages, \
     Subscription, CatalogSource, OperatorSource, OperatorGroup
-from piqe_ocp_lib.api.ocp_exceptions import OcpUnsupportedVersion
 from kubernetes.client.rest import ApiException
 import logging
 import yaml

--- a/piqe_ocp_lib/api/tasks/populate_cluster/populate_cluster.py
+++ b/piqe_ocp_lib/api/tasks/populate_cluster/populate_cluster.py
@@ -1,7 +1,4 @@
 #!/usr/bin/python
-import os
-import logging
-from datetime import datetime
 import argparse
 import time
 import sys

--- a/piqe_ocp_lib/tests/resources/test_ocp_apps.py
+++ b/piqe_ocp_lib/tests/resources/test_ocp_apps.py
@@ -48,7 +48,7 @@ class TestOcpApps(object):
                                                       template_location=setup_params['test_project'])
 
         for resource in res:
-            assert resource.metadata.name == setup_params['template_name']+'-'+str(setup_params['ident'])
+            assert resource.metadata.name == setup_params['template_name'] + '-' + str(setup_params['ident'])
 
     def test_delete_template_based_app(self, setup_params):
         """

--- a/piqe_ocp_lib/tests/resources/test_ocp_config_maps.py
+++ b/piqe_ocp_lib/tests/resources/test_ocp_config_maps.py
@@ -45,7 +45,7 @@ class TestOcpConfigMaps:
         logger.info("Get config maps")
         cm_response = ocp_cm.get_config_maps(namespace=NAMESPACE)
         if not cm_response and len(cm_response.items) <= 0:
-            assert False, f"Failed to get ConfigMaps"
+            assert False, "Failed to get ConfigMaps"
 
     def test_get_a_config_map(self, ocp_cm):
         logger.info(f"Get a {NAME} config map")
@@ -54,7 +54,7 @@ class TestOcpConfigMaps:
             assert False, f"Failed to get {NAME} ConfigMaps"
 
     def test_get_config_maps_names(self, ocp_cm):
-        logger.info(f"Get all config maps from specified namespace")
+        logger.info("Get all config maps from specified namespace")
         cm_names = ocp_cm.get_config_maps_names(namespace=NAMESPACE)
         if not cm_names and len(cm_names.items) <= 0:
             assert False, f"Failed to get ConfigMaps in {NAMESPACE} namespace"

--- a/piqe_ocp_lib/tests/resources/test_ocp_limit_ranges.py
+++ b/piqe_ocp_lib/tests/resources/test_ocp_limit_ranges.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__loggername__)
 
 five_digit_number = ''.join(random.sample('0123456789', 5))
 NAMESPACE = "default"
-NAME = f"test{five_digit_number}"
+NAME = "test{five_digit_number}"
 
 
 @pytest.fixture(scope="session")
@@ -47,63 +47,63 @@ def lr_body():
 class TestOcpLimitRanges:
 
     def test_container_limit_range_item_builder(self, ocp_lr):
-        logger.info(f"Create a Container V1LimitRangeItem")
+        logger.info("Create a Container V1LimitRangeItem")
         lr_item = ocp_lr.container_limit_range_item().memory(min="512Mb", max="1G").cpu(min="200M").build()
         logger.info(f"Create Response : {lr_item}")
         if not lr_item.min.get('memory') == '512Mb' and \
                 not lr_item.type == 'Container':
-            assert False, f"Failed to create Container V1LimitRangeItem"
+            assert False, "Failed to create Container V1LimitRangeItem"
 
     def test_pod_limit_range_item_builder(self, ocp_lr):
-        logger.info(f"Create a Pod V1LimitRangeItem")
+        logger.info("Create a Pod V1LimitRangeItem")
         lr_item = ocp_lr.pod_limit_range_item().memory(min="512Mb", max="1G").cpu(min="200M").build()
         logger.info(f"Create Response : {lr_item}")
         if not lr_item.min.get('cpu') == '200M' and \
                 not lr_item.type == 'Pod':
-            assert False, f"Failed to create Pod V1LimitRangeItem"
+            assert False, "Failed to create Pod V1LimitRangeItem"
 
     def test_image_limit_range_item_builder(self, ocp_lr):
-        logger.info(f"Create a Image V1LimitRangeItem")
+        logger.info("Create a Image V1LimitRangeItem")
         lr_item = ocp_lr.image_limit_range_item().storage(max="1G").build()
         logger.info(f"Create Response : {lr_item}")
         if not lr_item.max.get('storage') == '1G' and \
                 not lr_item.type == 'openshift.io/Image':
-            assert False, f"Failed to create Image V1LimitRangeItem"
+            assert False, "Failed to create Image V1LimitRangeItem"
 
     def test_image_stream_limit_range_item_builder(self, ocp_lr):
-        logger.info(f"Create a ImageStream V1LimitRangeItem")
+        logger.info("Create a ImageStream V1LimitRangeItem")
         lr_item = ocp_lr.image_stream_limit_range_item().images(max="10").build()
         logger.info(f"Create Response : {lr_item}")
         if not lr_item.max.get('images') == '10' and \
                 not lr_item.type == 'openshift.io/ImageStream':
-            assert False, f"Failed to create ImageStream V1LimitRangeItem"
+            assert False, "Failed to create ImageStream V1LimitRangeItem"
 
     def test_persistent_volume_claim_limit_range_item_builder(self, ocp_lr):
-        logger.info(f"Create a PersistentVolumeClaim V1LimitRangeItem")
+        logger.info("Create a PersistentVolumeClaim V1LimitRangeItem")
         lr_item = ocp_lr.persistent_volume_claim_limit_range_item().storage(max="10G").build()
         logger.info(f"Create Response : {lr_item}")
         if not lr_item.max.get('storage') == '10G' and \
                 not lr_item.type == 'PersistentVolumeClaim':
-            assert False, f"Failed to create PersistentVolumeClaim V1LimitRangeItem"
+            assert False, "Failed to create PersistentVolumeClaim V1LimitRangeItem"
 
     def test_build_limit_range(self, ocp_lr):
-        logger.info(f"Building a V1LimitRange")
+        logger.info("Building a V1LimitRange")
         lris = list()
         lris.append(ocp_lr.container_limit_range_item().memory(min="512Mb", max="1G").cpu(min="200M").build())
         lris.append(ocp_lr.persistent_volume_claim_limit_range_item().storage(max="10G").build())
         lr = ocp_lr.build_limit_range(name=NAME, namespace=NAMESPACE, item_list=lris)
         logger.info(f"Create Response : {lr}")
-        if not isinstance(lr.spec.limits, list)  and \
+        if not isinstance(lr.spec.limits, list) and \
                 len(lr.spec.limits) != 2:
-            assert False, f"Failed to build a V1LimitRange"
+            assert False, "Failed to build a V1LimitRange"
 
     def test_build_two_limit_range_items_not_equal(self, ocp_lr):
-        logger.info(f"Creating two V1LimitRangeItems")
+        logger.info("Creating two V1LimitRangeItems")
         clr1 = ocp_lr.container_limit_range_item().memory(min="512Mb", max="1G").cpu(min="200M").build()
         clr2 = ocp_lr.container_limit_range_item().memory(max="10G").build()
 
         if not (clr1 != clr2):
-            assert False, f"Failed to create two different V1LimitRangeItems"
+            assert False, "Failed to create two different V1LimitRangeItems"
 
     def test_create_limit_range(self, ocp_lr):
         logger.info(f"Create a {NAME} LimitRanges in {NAMESPACE} namespace")
@@ -122,7 +122,7 @@ class TestOcpLimitRanges:
         logger.info("Get limit ranges")
         lr_response = ocp_lr.get_limit_ranges(namespace=NAMESPACE)
         if not lr_response and len(lr_response.items) <= 0:
-            assert False, f"Failed to get LimitRanges"
+            assert False, "Failed to get LimitRanges"
 
     def test_get_a_limit_range(self, ocp_lr):
         logger.info(f"Get a {NAME} limit range")
@@ -131,13 +131,13 @@ class TestOcpLimitRanges:
             assert False, f"Failed to get {NAME} LimitRange"
 
     def test_get_limit_ranges_names(self, ocp_lr):
-        logger.info(f"Get names of all limit ranges from specified namespace")
+        logger.info("Get names of all limit ranges from specified namespace")
         lr_names = ocp_lr.get_limit_ranges_names(namespace=NAMESPACE)
         if not lr_names and len(lr_names) <= 0:
             assert False, f"Failed to get LimitRanges names in {NAMESPACE} namespace"
 
     def test_update_limit_range(self, ocp_lr):
-        logger.info(f"Patch a limit range from specified namespace")
+        logger.info("Patch a limit range from specified namespace")
         patch_set = [
             {
                 "type": "Container",
@@ -157,8 +157,7 @@ class TestOcpLimitRanges:
         assert lr_resp.spec.limits[0].min.cpu == '400M'
 
     def test_replace_limit_range(self, ocp_lr, lr_body):
-
-        logger.info(f"replace the LimitRange from specified namespace")
+        logger.info("replace the LimitRange from specified namespace")
         lr_body.get('spec').get('limits').append({
             "type": "Pod",
             "max": {"cpu": "1200M",

--- a/piqe_ocp_lib/tests/resources/test_ocp_limit_ranges.py
+++ b/piqe_ocp_lib/tests/resources/test_ocp_limit_ranges.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__loggername__)
 
 five_digit_number = ''.join(random.sample('0123456789', 5))
 NAMESPACE = "default"
-NAME = "test{five_digit_number}"
+NAME = f"test{five_digit_number}"
 
 
 @pytest.fixture(scope="session")

--- a/piqe_ocp_lib/tests/resources/test_ocp_templates.py
+++ b/piqe_ocp_lib/tests/resources/test_ocp_templates.py
@@ -159,7 +159,7 @@ class TestOcpTemplates(object):
         template = template_api_obj.get_a_template_in_a_namespace(setup_params['app_name'],
                                                                   project=setup_params['test_project'])
         api_response = template_api_obj.enumerate_unprocessed_template(template, setup_params['ident'])
-        assert api_response['parameters'][0]['value'] == setup_params['app_name']+'-'+str(setup_params['ident'])
+        assert api_response['parameters'][0]['value'] == setup_params['app_name'] + '-' + str(setup_params['ident'])
         logger.info("API Response : {}".format(api_response['parameters'][0]['value']))
 
         #
@@ -193,7 +193,7 @@ class TestOcpTemplates(object):
         enumrated_template = template_api_obj.enumerate_unprocessed_template(raw_template, setup_params['ident'])
         processed_template = template_api_obj.create_a_processed_template(enumrated_template)
         for resource in processed_template['objects']:
-            assert resource['metadata']['name'] == setup_params['app_name']+'-'+str(setup_params['ident'])
+            assert resource['metadata']['name'] == setup_params['app_name'] + '-' + str(setup_params['ident'])
             logger.info("Resource : {}".format(resource['metadata']['name']))
 
         #


### PR DESCRIPTION
This PR is blocking #27 due to CI errors. Current PRs are passing due to a unseen failure in our command:
`find . -name *.py`.  `*py` is being **expanded by the shell** resulting in command error and thus a success in our flake8 step.

![image](https://user-images.githubusercontent.com/24530683/109210991-60514e00-778c-11eb-9f20-8075a38b0321.png)


I didn't want to include black, isort or any other formater, I've kept it simple so we choose one later on.