### PR TITLE
[CSSWA-357] Pypi publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,50 @@
+name: Publish to PyPi
+
+# RELEASE PROCESS
+#
+# === Manual activities ===
+#
+# 1. Document human readable changes in CHANGELOG
+# 2. Bump package version using poetry version <major|minor|patch|specific version>
+
+#
+# === Automated activities ===
+#
+# 1. Publish package to PyPi test repository
+# 2. Publish package to PyPi prod repository
+
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: "3.8"
+
+    - name: Install dependencies
+      run: make dev
+
+    - name: Build python package and wheel
+      run: poetry run build
+
+    - name: Upload to Pypi test
+      run: make release-test
+      env:
+        PYPI_USERNAME: __token__
+        PYPI_TEST_TOKEN: ${{ secrets.PYPI_TEST_TOKEN }}
+
+    - name: Upload to PyPi prod
+      run: make release-prod
+      env:
+        PYPI_USERNAME: __token__
+        PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev format lint test build release
+.PHONY: dev format lint test build release-test release-prod
 
 dev:
 	pip install --upgrade pip poetry
@@ -17,6 +17,11 @@ test:
 build: lint test
 	poetry build
 
-release: build
+release-test:
+	poetry config repositories.testpypi https://test.pypi.org/simple
+	poetry config pypi-token.pypi ${PYPI_TEST_TOKEN}
+	poetry publish --repository testpypi -n
+
+release-prod:
 	poetry config pypi-token.pypi ${PYPI_TOKEN}
 	poetry publish --no-interaction

--- a/README.md
+++ b/README.md
@@ -26,24 +26,24 @@ Change directory to piqe-ocp-lib and create a virtual environment.
 
 Enter the virtual environment, export the environment variables and performn a pip install.
 
-    source scenario/bin/activate  
-    export WORKSPACE=$PWD  
-    export KUBECONFIG=/vagrant/auth/ocp43/kubeconfig  
+    source scenario/bin/activate
+    export WORKSPACE=$PWD
+    export KUBECONFIG=/vagrant/auth/ocp43/kubeconfig
     pip install .
 
 At this point, your environment is prepared. Verify that you can connect to your OpenShift instance.
 
     $ oc cluster-info
-    Kubernetes master is running at https://api.<yourdomain>.com:6443  
+    Kubernetes master is running at https://api.<yourdomain>.com:6443
 
 #### Try running a test
 
 The API library resides under piqe_ocp_lib/api/resources, and the corresponding tests reside under piqe_ocp_lib/tests/resources.
 
 Run the test_ocp_base tests
-  
+
     pytest -sv piqe_ocp_lib/tests/resources/test_ocp_base.py
-    
+
 Results similar to those shown below should be presented.
 
     ====================================== test session starts ======================================
@@ -52,13 +52,28 @@ Results similar to those shown below should be presented.
     OpenShift version: latest
     rootdir: /vagrant/piqe-test-libraries/piqe-ocp-lib
     plugins: dependency-0.5.1, forked-1.1.3, xdist-1.31.0
-    collected 1 item                                                                                
+    collected 1 item
 
     piqe-ocp-lib/tests/resources/test_ocp_base.py::TestOcpBase::test_init 2020-03-18 16:00:03,318 INFO (get_openshift_cluster_info) openshift tests default configs:
     {'first_master': None}
     2020-03-18 16:00:03,318 INFO (log_start_test_case) Starting test case: test_init
     2020-03-18 16:00:03,883 - [INFO] - piqe_api_logger - test_ocp_base@test_init:25 - The obtained version is: 4.3.0
     PASSED2020-03-18 16:00:03,884 INFO (log_end_test_case) Ending test case: test_init
-    
-    
+
+
     ======================================= 1 passed in 0.96s =======================================
+
+## Release process
+
+We're maintaining a log of changes for every release. Semantic versioning and Keep a Changelog were chosen as standards. You can find more information about both standards [here](CHANGELOG.md).
+
+This library shall be automatically published to Pypi following the steps below:
+1. Update `CHANGELOG.md` with the new changes (Keep a Changelog);
+2. Bump your package version with `poetry version major.minor.patch` (Semantic Versioning);
+3. Open a PR with these two changes above;
+4. Manually create a GitHub release;
+5. Successful CI will publish.
+
+### Further improvements
+
+We're currently not running any tests in our CI phase due to some limitations. We should target improving this and remove this burden from developers.

--- a/piqe_ocp_lib/tests/conftest.py
+++ b/piqe_ocp_lib/tests/conftest.py
@@ -18,8 +18,12 @@ def pytest_addoption(parser):
         default="latest",
         help="Version of OpenShift to test against for functional tests",
     )
-    parser.addoption("--openshift-first-master", action="store", help="Openshift first master HOSTNAME/IP", default=None)
-    parser.addoption("--openshift-default-tests-config", action="store", help="Openshift default tests config file", default=None)
+    parser.addoption(
+        "--openshift-first-master", action="store", help="Openshift first master HOSTNAME/IP", default=None
+    )
+    parser.addoption(
+        "--openshift-default-tests-config", action="store", help="Openshift default tests config file", default=None
+    )
     parser.addoption("--openshift-tests-log-dir", action="store", default="./logs/", help="Openshift tests logs dir")
     parser.addoption("--openshift-tests-log-level", action="store", default="INFO", help="Openshift tests log level")
     parser.addoption("--log-to-stdout", action="store", default="True", help="Log output to stdout as well as file")


### PR DESCRIPTION
Add automation to enable pypi publishing.

The proposal here is to automatically publish whenever we make a github release. The proposed pipeline is the following:
1. Gather changes and write down to `CHANGELOG.md`
2. bump package version with: `poetry version major.minor.patch`
3. Open PR and wait for CI
4. Create a github release.
5. Package is automatically updated to pypi