### PR TITLE
fix downstream CI test failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Change directory to piqe-ocp-lib and create a virtual environment.
 Enter the virtual environment, export the environment variables and performn a pip install.
 
     source scenario/bin/activate
-    export WORKSPACE=$PWD
     export KUBECONFIG=/vagrant/auth/ocp43/kubeconfig
     pip install .
 
@@ -62,6 +61,14 @@ Results similar to those shown below should be presented.
 
 
     ======================================= 1 passed in 0.96s =======================================
+
+#### Cluster Config
+
+Some task-level APIs or tests require the use of a cluster_config yaml file that describes 
+the layout of the cluster and the resources being deployed. You can either specify the file using a command
+line flag or set the variable `PIQE_OCP_LIB_CLUSTER_CONF` variable to the path. 
+
+For reference you can refer to the one used in our tests [here](piqe_ocp_lib/tests/config/smoke_ocp_config.yaml)
 
 ## Release process
 

--- a/piqe_ocp_lib/api/tasks/populate_cluster/populate_cluster.py
+++ b/piqe_ocp_lib/api/tasks/populate_cluster/populate_cluster.py
@@ -8,6 +8,7 @@ import threading
 from threading import Lock
 import time
 from time import sleep
+import os
 
 from piqe_ocp_lib import __loggername__
 from piqe_ocp_lib.api import ocp_exceptions
@@ -434,9 +435,13 @@ def argument_parser():
 
     # Define arguments
     parser = argparse.ArgumentParser(description="Process inputs for populate_ocp_cluster")
-
+    if 'PIQE_OCP_LIB_CLUSTER_CONF' in os.environ and os.environ['PIQE_OCP_LIB_CLUSTER_CONF']:
+        cfg_path = os.path.abspath(os.path.expandvars(os.path.expanduser(os.environ['PIQE_OCP_LIB_CLUSTER_CONF'])))
+        confopt = {'default': cfg_path}
+    else:
+        confopt = {'required': True}
     parser.add_argument(
-        "-c", "--config", action="store", required=True, help="YAML Config file that describes the cluster"
+        "-c", "--config", action="store", help="YAML Config file that describes the cluster", **confopt
     )
     parser.add_argument(
         "-d",

--- a/piqe_ocp_lib/tests/resources/test_ocp_operators.py
+++ b/piqe_ocp_lib/tests/resources/test_ocp_operators.py
@@ -278,7 +278,8 @@ class TestInstallOperatorWorkflow:
         project_resource.create_a_project("test-project4")
         operator_installer.add_operator_to_cluster("amq-streams", target_namespaces=["test-project4"])
         csv_name = operator_hub.get_package_singlenamespace_channel("amq-streams").currentCSV
-        assert cluster_service.is_cluster_service_version_present(csv_name, "test-project4")
+        # increased timeout because on slow virtual clusters the default 30 seconds may not be enough
+        assert cluster_service.is_cluster_service_version_present(csv_name, "test-project4", timeout=60)
         # TODO: update when delete_operator_from_cluster is implemented
         project_resource.delete_a_project("test-amq-streams-singlenamespace-og-sub-project")
         project_resource.delete_a_project("test-project4")
@@ -290,8 +291,9 @@ class TestInstallOperatorWorkflow:
 
         csv_name = operator_hub.get_package_multinamespace_channel("amq-streams").currentCSV
 
-        assert cluster_service.is_cluster_service_version_present(csv_name, "test-project5")
-        assert cluster_service.is_cluster_service_version_present(csv_name, "test-project6")
+        # increased timeout because on slow virtual clusters the default 30 seconds may not be enough
+        assert cluster_service.is_cluster_service_version_present(csv_name, "test-project5", timeout=60)
+        assert cluster_service.is_cluster_service_version_present(csv_name, "test-project6", timeout=60)
 
         # TODO: update when delete_operator_from_cluster is implemented
         project_resource.delete_a_project("test-amq-streams-multinamespace-og-sub-project")
@@ -305,7 +307,8 @@ class TestInstallOperatorWorkflow:
         all_projects = project_resource.get_all_projects()
 
         for project in all_projects.items:
-            assert cluster_service.is_cluster_service_version_present(csv_name, project.metadata.name)
+            # increased timeout because on slow virtual clusters the default 30 seconds may not be enough
+            assert cluster_service.is_cluster_service_version_present(csv_name, project.metadata.name, timeout=60)
 
         project_resource.delete_a_project("test-amq-streams-allnamespaces-og-sub-project")
         project_resource.delete_a_project("test-project7")

--- a/piqe_ocp_lib/tests/resources/test_ocp_virtual_machine.py
+++ b/piqe_ocp_lib/tests/resources/test_ocp_virtual_machine.py
@@ -10,6 +10,7 @@ from piqe_ocp_lib.api.resources.ocp_virtual_machine import (
     VirtualMachineSubResourcesClient,
 )
 
+pytestmark = pytest.mark.requiresoperator('kubevirt-hyperconverged')
 
 @pytest.fixture(scope="module")
 def vm_name() -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ ipdb = "^0.13.7"
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "-s"
+addopts = "-s -rxs"
 testpaths = ["./piqe_ocp_lib/tests"]
 markers = [
     "populate",


### PR DESCRIPTION
 * Some of the task level tests fail to find the cluster
   config file because it depended on the env variable
   WORKSPACE being set to the PWD but in the Jenkins context
   that is not always the case and trickier to do. Added
   a reliable way to find the default smoke_cluster_config.yml
   and an optional library specific env variable rather than
   relying on WORKSPACE.

 * One of the tests was failing because the mocked parameters
   being passed to the test function were not in the proper
   order