### PR TITLE
CSSWA-291: drop python2 support

### DIFF
--- a/piqe_ocp_lib/__init__.py
+++ b/piqe_ocp_lib/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2019 Red Hat, Inc.
 #

--- a/piqe_ocp_lib/api/crd/ocp_argocd_applications.py
+++ b/piqe_ocp_lib/api/crd/ocp_argocd_applications.py
@@ -24,7 +24,7 @@ class OcpArgocdApplications(OcpBase):
     """
 
     def __init__(self, kube_config_file=None):
-        super(OcpArgocdApplications, self).__init__(kube_config_file=kube_config_file)
+        super().__init__(kube_config_file=kube_config_file)
         self.api_version = "argoproj.io/v1alpha1"
         self.kind = "Application"
         self.ocp_argocd_app = self.dyn_client.resources.get(api_version=self.api_version, kind=self.kind)

--- a/piqe_ocp_lib/api/crd/ocp_managed_cluster.py
+++ b/piqe_ocp_lib/api/crd/ocp_managed_cluster.py
@@ -17,7 +17,7 @@ class OcpManagedCluster(OcpBase):
     """
 
     def __init__(self, kube_config_file=None):
-        super(OcpManagedCluster, self).__init__(kube_config_file=kube_config_file)
+        super().__init__(kube_config_file=kube_config_file)
         self.api_version = "cluster.open-cluster-management.io/v1"
         self.kind = "ManagedCluster"
         self.ocp_managed_cluster = self.dyn_client.resources.get(api_version=self.api_version, kind=self.kind)

--- a/piqe_ocp_lib/api/crd/ocp_pipeline_runs.py
+++ b/piqe_ocp_lib/api/crd/ocp_pipeline_runs.py
@@ -22,7 +22,7 @@ class OcpPipelines(OcpBase):
     """
 
     def __init__(self, kube_config_file=None):
-        super(OcpPipelines, self).__init__(kube_config_file=kube_config_file)
+        super().__init__(kube_config_file=kube_config_file)
         self.api_version = "tekton.dev/v1beta1"
         self.kind = "Pipeline"
         self.ocp_pipeline = self.dyn_client.resources.get(api_version=self.api_version, kind=self.kind)
@@ -123,7 +123,7 @@ class OcpPipelineRuns(OcpBase):
     """
 
     def __init__(self, kube_config_file=None):
-        super(OcpPipelineRuns, self).__init__(kube_config_file=kube_config_file)
+        super().__init__(kube_config_file=kube_config_file)
         self.api_version = "tekton.dev/v1beta1"
         self.kind = "PipelineRun"
         self.ocp_pipeline_runs = self.dyn_client.resources.get(api_version=self.api_version, kind=self.kind)
@@ -224,7 +224,7 @@ class OcpPipelineRuns(OcpBase):
         """
         logger.info(f"Watching pod {pipeline_run_name} for readiness")
         pipeline_run_ready = False
-        field_selector = "metadata.name={}".format(pipeline_run_name)
+        field_selector = f"metadata.name={pipeline_run_name}"
         for event in self.ocp_pipeline_runs.watch(namespace=namespace, field_selector=field_selector, timeout=timeout):
             for pipeline_run_condition in event["object"]["status"]["conditions"]:
                 if pipeline_run_condition["status"] == "True" and pipeline_run_condition["type"] == "Succeeded":

--- a/piqe_ocp_lib/api/monitoring/ocp_prometheus_client.py
+++ b/piqe_ocp_lib/api/monitoring/ocp_prometheus_client.py
@@ -50,7 +50,7 @@ class OcpPrometheusClient(OcpBase):
     """
 
     def __init__(self, kube_config_file=None):
-        super(OcpPrometheusClient, self).__init__(kube_config_file=kube_config_file)
+        super().__init__(kube_config_file=kube_config_file)
         self.ocp_route = OcpRoutes(kube_config_file=kube_config_file)
         self.ocp_secret = OcpSecret(kube_config_file=kube_config_file)
         self._prometheus_cache = dict()

--- a/piqe_ocp_lib/api/resources/ocp_base.py
+++ b/piqe_ocp_lib/api/resources/ocp_base.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__loggername__)
 
 Version = namedtuple("Version", ["major", "minor", "patch"])
 
+
 class OcpBase(object):
     """
     This dict will hold kubeconfig as key and DynamicClient object as value
@@ -98,11 +99,11 @@ class OcpBase(object):
         except ApiException as e:
             logger.exception(f"Exception was encountered while trying to obtain cluster version: {e}")
             return None
-         
+
         version_query = "sort_by(status.history[?state=='Completed'], &completionTime)[::-1].version"
         version = jmespath.search(version_query, version.to_dict())
-        if 'nightly'in version[0]:
-            version=[(version[0].split('-'))[0]]
+        if "nightly" in version[0]:
+            version = [(version[0].split("-"))[0]]
         return Version(*map(int, version[0].split(".")))
 
     def _get_infrastructure_provider(self):

--- a/piqe_ocp_lib/api/resources/ocp_base.py
+++ b/piqe_ocp_lib/api/resources/ocp_base.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__loggername__)
 Version = namedtuple("Version", ["major", "minor", "patch"])
 
 
-class OcpBase(object):
+class OcpBase:
     """
     This dict will hold kubeconfig as key and DynamicClient object as value
     """
@@ -112,19 +112,19 @@ class OcpBase(object):
         instpecting the Infastructure resource.
         :return: (str) The name of the infrastructure provider or None
         """
-        provider = str()
+        provider = ''
         try:
             api_response = self.dyn_client.resources.search(api_version="config.openshift.io/v1", kind="Infrastructure")
             assert isinstance(api_response, list)
         except ApiException as e:
-            logger.exception("Exception was encountered while trying to get the infrastructure resource: {}".format(e))
+            logger.exception(f"Exception was encountered while trying to get the infrastructure resource: {e}")
         if api_response and isinstance(api_response[0], Resource) and api_response[0].kind == "Infrastructure":
             api_response = api_response[0]
             infra_obj = api_response.get()
             try:
                 provider = infra_obj.items[0].spec.platformSpec.type
             except KeyError:
-                logger.error("Could not access the platformSpec key in Infrastructure: \n{}".format(infra_obj))
+                logger.error(f"Could not access the platformSpec key in Infrastructure: \n{infra_obj}")
         return provider
 
     def get_data_from_kubeconfig_v4(self):

--- a/piqe_ocp_lib/api/resources/ocp_cluster_operators.py
+++ b/piqe_ocp_lib/api/resources/ocp_cluster_operators.py
@@ -17,7 +17,7 @@ class OcpClusterOperator(OcpBase):
     """
 
     def __init__(self, kube_config_file=None):
-        super(OcpClusterOperator, self).__init__(kube_config_file=kube_config_file)
+        super().__init__(kube_config_file=kube_config_file)
         self.api_version = "config.openshift.io/v1"
         self.kind = "ClusterOperator"
         self.ocp_co = self.dyn_client.resources.get(api_version=self.api_version, kind=self.kind)

--- a/piqe_ocp_lib/api/resources/ocp_cluster_versions.py
+++ b/piqe_ocp_lib/api/resources/ocp_cluster_versions.py
@@ -21,7 +21,7 @@ class OcpClusterVersion(OcpBase):
     """
 
     def __init__(self, kube_config_file=None):
-        super(OcpClusterVersion, self).__init__(kube_config_file=kube_config_file)
+        super().__init__(kube_config_file=kube_config_file)
         self.api_version = "config.openshift.io/v1"
         self.kind = "ClusterVersion"
         self.ocp_cv = self.dyn_client.resources.get(api_version=self.api_version, kind=self.kind)
@@ -129,7 +129,7 @@ class OcpClusterVersion(OcpBase):
                 lambda updates: any(kind in channel for channel in updates["channels"]), available_channels
             )
 
-        available_channels = set().union(*[e["channels"] for e in available_channels])
+        available_channels = set().union(*(e["channels"] for e in available_channels))
 
         return available_channels
 

--- a/piqe_ocp_lib/api/resources/ocp_config_maps.py
+++ b/piqe_ocp_lib/api/resources/ocp_config_maps.py
@@ -17,7 +17,7 @@ class OcpConfigMaps(OcpBase):
     """
 
     def __init__(self, kube_config_file=None):
-        super(OcpConfigMaps, self).__init__(kube_config_file=kube_config_file)
+        super().__init__(kube_config_file=kube_config_file)
         self.api_version = "v1"
         self.kind = "ConfigMap"
         self.ocp_config_map = self.dyn_client.resources.get(api_version=self.api_version, kind=self.kind)

--- a/piqe_ocp_lib/api/resources/ocp_configs.py
+++ b/piqe_ocp_lib/api/resources/ocp_configs.py
@@ -19,7 +19,7 @@ class OcpConfig(OcpBase):
     """
 
     def __init__(self, kind, api_version, kube_config_file=None):
-        super(OcpConfig, self).__init__(kube_config_file=kube_config_file)
+        super().__init__(kube_config_file=kube_config_file)
         self.kube_config_file = kube_config_file
         self.ocp_config = self.dyn_client.resources.get(api_version=api_version, kind=kind)
 

--- a/piqe_ocp_lib/api/resources/ocp_control_planes.py
+++ b/piqe_ocp_lib/api/resources/ocp_control_planes.py
@@ -17,7 +17,7 @@ class OcpControlPlane(OcpBase):
     """
 
     def __init__(self, kube_config_file=None):
-        super(OcpControlPlane, self).__init__(kube_config_file=kube_config_file)
+        super().__init__(kube_config_file=kube_config_file)
         self.api_version = "v1"
         self.kind = "ComponentStatus"
         self.ocp_control_plane = self.dyn_client.resources.get(api_version=self.api_version, kind=self.kind)

--- a/piqe_ocp_lib/api/resources/ocp_deploymentconfigs.py
+++ b/piqe_ocp_lib/api/resources/ocp_deploymentconfigs.py
@@ -19,7 +19,7 @@ class OcpDeploymentconfigs(OcpBase):
     """
 
     def __init__(self, kind="DeploymentConfig", kube_config_file=None):
-        super(OcpDeploymentconfigs, self).__init__(kube_config_file=kube_config_file)
+        super().__init__(kube_config_file=kube_config_file)
         self.api_version = "v1"
         self.ocp_dcs = self.dyn_client.resources.get(api_version=self.api_version, kind=kind)
 

--- a/piqe_ocp_lib/api/resources/ocp_health_checker.py
+++ b/piqe_ocp_lib/api/resources/ocp_health_checker.py
@@ -42,7 +42,7 @@ class OcpHealthChecker(OcpBase):
 
     def __init__(self, kube_config_file):
         self.kube_config_file = kube_config_file
-        super(OcpHealthChecker, self).__init__(kube_config_file=self.kube_config_file)
+        super().__init__(kube_config_file=self.kube_config_file)
         self.ocp_node = OcpNodes(kube_config_file=self.kube_config_file)
         self.ocp_cluster_operator = OcpClusterOperator(kube_config_file=self.kube_config_file)
         self.ocp_control_plane = OcpControlPlane(kube_config_file=self.kube_config_file)

--- a/piqe_ocp_lib/api/resources/ocp_limit_ranges.py
+++ b/piqe_ocp_lib/api/resources/ocp_limit_ranges.py
@@ -20,7 +20,7 @@ class OcpLimitRanges(OcpBase):
     """
 
     def __init__(self, kube_config_file=None):
-        super(OcpLimitRanges, self).__init__(kube_config_file=kube_config_file)
+        super().__init__(kube_config_file=kube_config_file)
         self.api_version = "v1"
         self.kind = "LimitRange"
         self.ocp_limit_range = self.dyn_client.resources.get(api_version=self.api_version, kind=self.kind)
@@ -246,7 +246,7 @@ class OcpLimitRanges(OcpBase):
         )
 
 
-class OcpLimitRangeItem(object):
+class OcpLimitRangeItem:
     """
     OcpContainerLimit Class is a builder that encapsulates
     that kubernetes V1LimitRangeItem class so that it's easier to build with values
@@ -334,7 +334,7 @@ class OcpContainerLimit(OcpLimitRangeItem):
 
     def __init__(self):
 
-        super(OcpContainerLimit, self).__init__(type="Container")
+        super().__init__(type="Container")
 
     def cpu(
         self,
@@ -402,7 +402,7 @@ class OcpPodLimit(OcpLimitRangeItem):
 
     def __init__(self):
 
-        super(OcpPodLimit, self).__init__(type="Pod")
+        super().__init__(type="Pod")
 
     def cpu(
         self, min: Union[str, None] = None, max: Union[str, None] = None, max_limit_ratio: Union[str, None] = None
@@ -442,7 +442,7 @@ class OcpImageLimit(OcpLimitRangeItem):
 
     def __init__(self):
 
-        super(OcpImageLimit, self).__init__(type="openshift.io/Image")
+        super().__init__(type="openshift.io/Image")
 
     def storage(self, max: Union[str, None] = None) -> Type["OcpImageLimit"]:
         """
@@ -464,7 +464,7 @@ class OcpImageStreamLimit(OcpLimitRangeItem):
 
     def __init__(self):
 
-        super(OcpImageStreamLimit, self).__init__(type="openshift.io/ImageStream")
+        super().__init__(type="openshift.io/ImageStream")
 
     def image_tags(self, max: Union[str, None] = None) -> Type["OcpImageStreamLimit"]:
         """
@@ -498,7 +498,7 @@ class OcpPersistentVolumeClaimLimit(OcpLimitRangeItem):
 
     def __init__(self):
 
-        super(OcpPersistentVolumeClaimLimit, self).__init__(type="PersistentVolumeClaim")
+        super().__init__(type="PersistentVolumeClaim")
 
     def storage(
         self, min: Union[str, None] = None, max: Union[str, None] = None

--- a/piqe_ocp_lib/api/resources/ocp_machine_management.py
+++ b/piqe_ocp_lib/api/resources/ocp_machine_management.py
@@ -21,7 +21,7 @@ class OcpMachineSet(OcpBase):
     """
 
     def __init__(self, kube_config_file=None):
-        super(OcpMachineSet, self).__init__(kube_config_file=kube_config_file)
+        super().__init__(kube_config_file=kube_config_file)
         self.api_version = "machine.openshift.io/v1beta1"
         self.kind = "MachineSet"
         self.machineset = self.dyn_client.resources.get(api_version=self.api_version, kind=self.kind)
@@ -61,7 +61,7 @@ class OcpMachineSet(OcpBase):
         :param machine_set_name: (str) name of the machine set
         :return: Machine set role on success OR empty string on failure
         """
-        role = str()
+        role = ''
         machine_set = self.get_machine_set(machine_set_name)
         role = machine_set.metadata.labels["machine.openshift.io/cluster-api-machine-role"]
         return role
@@ -138,7 +138,7 @@ class OcpMachineSet(OcpBase):
             node_names_to_be_deleted = list()
             for machine in machine_names_to_be_deleted:
                 node_names_to_be_deleted.append(self.machine.get_machine_node_ref(machine))
-            logger.debug("Machines to be deleted are: {}".format(machine_names_to_be_deleted))
+            logger.debug(f"Machines to be deleted are: {machine_names_to_be_deleted}")
             excess_machines_deleted = True
             for machine_name in machine_names_to_be_deleted:
                 excess_machines_deleted = excess_machines_deleted and self.machine.is_machine_deleted(machine_name)
@@ -171,7 +171,7 @@ class OcpMachineSet(OcpBase):
             return False
 
         initial_machines = self.machine.get_machines_in_machineset(machine_set_name)
-        initial_machine_names = set([machine.metadata.name for machine in initial_machines.items])
+        initial_machine_names = {machine.metadata.name for machine in initial_machines.items}
         initial_machines_count = len(initial_machine_names)
         # If number of existing machine is the same as replicas, nothing to do.
         if initial_machines_count == replicas:
@@ -207,7 +207,7 @@ class OcpMachines(OcpBase):
     """
 
     def __init__(self, kube_config_file=None):
-        super(OcpMachines, self).__init__(kube_config_file=kube_config_file)
+        super().__init__(kube_config_file=kube_config_file)
         self.api_version = "machine.openshift.io/v1beta1"
         self.kind = "Machine"
         self.machine = self.dyn_client.resources.get(api_version=self.api_version, kind=self.kind)
@@ -264,8 +264,8 @@ class OcpMachines(OcpBase):
         if "machine.openshift.io/cluster-api-machineset" in machine.metadata.labels.keys():
             return machine.metadata.labels["machine.openshift.io/cluster-api-machineset"]
         else:
-            logger.warning("machine {} with role {} is not part of machineset".format(machine_name, machine_role))
-            return str()
+            logger.warning(f"machine {machine_name} with role {machine_role} is not part of machineset")
+            return ''
 
     def get_machines_in_machineset(self, machine_set: str) -> ResourceList:
         """
@@ -294,12 +294,12 @@ class OcpMachines(OcpBase):
             try:
                 node_name = event["object"]["status"]["nodeRef"]["name"]
             except TypeError:
-                logger.warning("Machine {} doesn't have a nodeRef field yet ...".format(machine_name))
+                logger.warning(f"Machine {machine_name} doesn't have a nodeRef field yet ...")
                 continue
             else:
-                logger.debug("Machine ref detected with values: {}".format(node_name))
+                logger.debug(f"Machine ref detected with values: {node_name}")
                 return node_name
-        logger.error("Unable to obtain a nodeRef out of Machine: {}".format(machine_name))
+        logger.error(f"Unable to obtain a nodeRef out of Machine: {machine_name}")
         return None
 
     def is_machine_created(self, machine_name: str, timeout: int = TIMEOUT) -> bool:
@@ -315,12 +315,12 @@ class OcpMachines(OcpBase):
                 vm_state = event["object"]["status"]["providerStatus"]["vmState"]
                 provider_status_condition = event["object"]["status"]["providerStatus"]["conditions"]
             except TypeError:
-                logger.warning("Provider Status for machine {} has not yet been detected ...".format(machine_name))
+                logger.warning(f"Provider Status for machine {machine_name} has not yet been detected ...")
                 continue
             else:
                 if provider_status_condition[0]["type"] == "MachineCreated":
                     if vm_state == "Running":
-                        logger.debug("Machine {} has reached 'Running state'".format(machine_name))
+                        logger.debug(f"Machine {machine_name} has reached 'Running state'")
                         return True
                     else:
                         logger.debug(

--- a/piqe_ocp_lib/api/resources/ocp_node_metrics.py
+++ b/piqe_ocp_lib/api/resources/ocp_node_metrics.py
@@ -17,7 +17,7 @@ class OcpNodeMetrics(OcpBase):
     """
 
     def __init__(self, kube_config_file=None):
-        super(OcpNodeMetrics, self).__init__(kube_config_file=kube_config_file)
+        super().__init__(kube_config_file=kube_config_file)
         self.api_version = "metrics.k8s.io/v1beta1"
         self.kind = "NodeMetrics"
         self.ocp_nodes = self.dyn_client.resources.get(api_version=self.api_version, kind=self.kind)

--- a/piqe_ocp_lib/api/resources/ocp_nodes.py
+++ b/piqe_ocp_lib/api/resources/ocp_nodes.py
@@ -90,12 +90,12 @@ class OcpNodes(OcpBase):
         :param timeout: (int) The time limit for polling status. Defaults to 300
         :return: (bool) True if it's Ready OR False otherwise
         """
-        field_selector = "metadata.name={}".format(node_name)
+        field_selector = f"metadata.name={node_name}"
         for event in self.ocp_nodes.watch(field_selector=field_selector, timeout=timeout):
             conditions_list = event["object"]["status"]["conditions"]
             latest_event = conditions_list[-1]
             if conditions_list and latest_event["type"] == "Ready" and latest_event["status"] == "True":
-                logger.debug("Node {} has reached 'Ready' state".format(node_name))
+                logger.debug(f"Node {node_name} has reached 'Ready' state")
                 return True
             else:
                 logger.debug(
@@ -112,11 +112,11 @@ class OcpNodes(OcpBase):
         :return: (bool) True if it's deleted OR False otherwise
         """
         if self.get_a_node(node_name) is None:
-            logger.info("Node {} is not present".format(node_name))
+            logger.info(f"Node {node_name} is not present")
             return True
         else:
             logger.debug("Node seems to be present, let's watch")
-            field_selector = "metadata.name={}".format(node_name)
+            field_selector = f"metadata.name={node_name}"
             for event in self.ocp_nodes.watch(field_selector=field_selector, timeout=timeout):
                 if self.get_a_node(node_name):
                     logger.debug("Node is still present")
@@ -248,7 +248,7 @@ class OcpNodes(OcpBase):
             if ret != 0:
                 return ret, out, err
         # Execute the command
-        command = "kubectl exec %s -- %s" % (pod_name, command_to_execute)
+        command = f"kubectl exec {pod_name} -- {command_to_execute}"
         logger.info("Executing command: %s", command)
         subp = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         out, err = subp.communicate()

--- a/piqe_ocp_lib/api/resources/ocp_operators.py
+++ b/piqe_ocp_lib/api/resources/ocp_operators.py
@@ -1,11 +1,11 @@
+import json
 import logging
 from time import sleep
-import warnings
-import json
 from typing import Optional, Union
-from openshift.dynamic.resource import ResourceInstance, ResourceList, Subresource
+import warnings
 
 from kubernetes.client.rest import ApiException
+from openshift.dynamic.resource import ResourceInstance, ResourceList, Subresource
 
 from piqe_ocp_lib import __loggername__
 from piqe_ocp_lib.api.resources import OcpBase
@@ -141,8 +141,8 @@ class OperatorhubPackages(OcpBase):
         :return: (str) The name of the suggested operator namespace if present, otherwise it returns None.
         """
         channel = self.get_package_channel_by_name(package_name, channel_name)
-        if channel and hasattr(channel.currentCSVDesc.annotations, 'operatorframework.io/suggested-namespace'):
-            return channel.currentCSVDesc.annotations['operatorframework.io/suggested-namespace']
+        if channel and hasattr(channel.currentCSVDesc.annotations, "operatorframework.io/suggested-namespace"):
+            return channel.currentCSVDesc.annotations["operatorframework.io/suggested-namespace"]
         else:
             logger.error("No suggested namespace was found for this channel")
         return None
@@ -235,7 +235,7 @@ class OperatorhubPackages(OcpBase):
         :return: (str) The defualt channel name, otherwise it returns None.
         """
         package_namnifest = self.get_package_manifest(package_name)
-        if not hasattr(package_namnifest.status, 'defaultChannel'):
+        if not hasattr(package_namnifest.status, "defaultChannel"):
             return None
         else:
             return package_namnifest.status.defaultChannel
@@ -268,7 +268,7 @@ class OperatorhubPackages(OcpBase):
             if channel.name == channel_name:
                 target_channel = channel
                 break
-        alm = target_channel.currentCSVDesc.annotations['alm-examples']
+        alm = target_channel.currentCSVDesc.annotations["alm-examples"]
         alm_list = json.loads(alm)
         return alm_list
 
@@ -373,22 +373,19 @@ class CatalogSource(OcpBase):
         self.kind = "CatalogSource"
         self.catalog_source_obj = self.dyn_client.resources.get(api_version=self.api_version, kind=self.kind)
 
-    def create_catalog_source(self, cs_name,
-                              image,
-                              displayName="Optional operators",
-                              publisher="Red Hat",
-                              namespace="openshift-marketplace"):
+    def create_catalog_source(
+        self, cs_name, image, displayName="Optional operators", publisher="Red Hat", namespace="openshift-marketplace"
+    ):
         cs_body = {
-
             "apiVersion": self.api_version,
             "kind": self.kind,
             "metadata": {"name": cs_name, "namespace": namespace},
-            'spec': {
-                'displayName': displayName,
-                'icon': {'base64data': '', 'mediatype': ''},
-                'image': image,
-                'publisher': publisher,
-                'sourceType': 'grpc',
+            "spec": {
+                "displayName": displayName,
+                "icon": {"base64data": "", "mediatype": ""},
+                "image": image,
+                "publisher": publisher,
+                "sourceType": "grpc",
             },
         }
         api_response = None
@@ -437,9 +434,9 @@ class CatalogSource(OcpBase):
             logger.exception("Exception when calling method get_all_catalog_sources: %s\n" % e)
         return api_response
 
-    def is_catalog_source_present(self, cs_name: str,
-                                  namespace: str = "openshift-marketplace",
-                                  timeout: int = 30) -> bool:
+    def is_catalog_source_present(
+        self, cs_name: str, namespace: str = "openshift-marketplace", timeout: int = 30
+    ) -> bool:
         """
         A method that verifies that a catalog source was created in a namespace. By default it
         will be 'openshift-marketplace'
@@ -508,7 +505,7 @@ class Subscription(OcpBase):
                 "name": operator_name,
                 "source": cs_name,
                 "sourceNamespace": cs_namespace,
-                "startingCSV": csv_name
+                "startingCSV": csv_name,
             },
         }
         api_response = None
@@ -577,9 +574,9 @@ class OperatorGroup(OcpBase):
         self.kind = "OperatorGroup"
         self.operator_group_obj = self.dyn_client.resources.get(api_version=self.api_version, kind=self.kind)
 
-    def create_operator_group(self, og_name: str,
-                              namespace: str,
-                              target_namespaces: Union[list, str] = []) -> ResourceInstance:
+    def create_operator_group(
+        self, og_name: str, namespace: str, target_namespaces: Union[list, str] = []
+    ) -> ResourceInstance:
         """
         A method to create an OperatorGroup object. If 'spec' is left out, it means that by default
         this operator group will target all namespaces for deployment. Otherwise, spec will contain
@@ -596,7 +593,7 @@ class OperatorGroup(OcpBase):
                                   otherwise, target namespaces will be a list.
         """
         # Verify that if target_namespaces default is overriden, it is of type list or '*'.
-        if not (isinstance(target_namespaces, list) or target_namespaces == '*'):
+        if not (isinstance(target_namespaces, list) or target_namespaces == "*"):
             err_msg = "'target_namespaces' argument must be provided in either list format or be exactly '*'"
             logger.exception(err_msg)
             raise ValueError(err_msg)
@@ -610,7 +607,7 @@ class OperatorGroup(OcpBase):
         # If target_namespaces is not the default [], add it to the body as part of 'spec'
         if target_namespaces == []:
             og_body.update({"spec": {"targetNamespaces": [namespace]}})
-        elif target_namespaces != '*':
+        elif target_namespaces != "*":
             og_body.update({"spec": {"targetNamespaces": target_namespaces}})
         try:
             api_response = self.operator_group_obj.apply(body=og_body)

--- a/piqe_ocp_lib/api/resources/ocp_operators.py
+++ b/piqe_ocp_lib/api/resources/ocp_operators.py
@@ -23,7 +23,7 @@ class OperatorhubPackages(OcpBase):
     """
 
     def __init__(self, kube_config_file=None):
-        super(OperatorhubPackages, self).__init__(kube_config_file=kube_config_file)
+        super().__init__(kube_config_file=kube_config_file)
         self.api_version = "packages.operators.coreos.com/v1"
         self.kind = "PackageManifest"
         self.package_manifest_obj = self.dyn_client.resources.get(api_version=self.api_version, kind=self.kind)
@@ -48,7 +48,7 @@ class OperatorhubPackages(OcpBase):
             if not catalog:
                 packages_obj_list = self.package_manifest_obj.get()
             else:
-                packages_obj_list = self.package_manifest_obj.get(label_selector="catalog={}".format(catalog))
+                packages_obj_list = self.package_manifest_obj.get(label_selector=f"catalog={catalog}")
         except ApiException as e:
             logger.exception("Exception when calling method get_package_manifest_list: %s\n" % e)
         return packages_obj_list
@@ -62,13 +62,13 @@ class OperatorhubPackages(OcpBase):
         """
         package_obj = None
         try:
-            package_obj = self.package_manifest_obj.get(field_selector="metadata.name={}".format(package_name))
+            package_obj = self.package_manifest_obj.get(field_selector=f"metadata.name={package_name}")
         except ApiException as e:
             logger.exception("Exception when calling method get_package_manifest: %s\n" % e)
         if package_obj and len(package_obj.items) == 1:
             return package_obj.items[0]
         elif len(package_obj.items) == 0:
-            logger.exception("The package {}, could not be detected".format(package_name))
+            logger.exception(f"The package {package_name}, could not be detected")
             return None
         else:
             return package_obj.items
@@ -87,9 +87,9 @@ class OperatorhubPackages(OcpBase):
             if not self.get_package_manifest(package_name):
                 counter += 5
                 sleep(5)
-                logger.info("Waiting for package {} to be available in OperatorHub".format(package_name))
+                logger.info(f"Waiting for package {package_name} to be available in OperatorHub")
             else:
-                logger.info("Package {} was detected in OperatorHub".format(package_name))
+                logger.info(f"Package {package_name} was detected in OperatorHub")
                 return True
         return False
 
@@ -102,7 +102,7 @@ class OperatorhubPackages(OcpBase):
         :return: (list) A list of subscription channels.
         """
         if not self.watch_package_manifest_present(package_name):
-            logger.error("The package {} could not be detected".format(package_name))
+            logger.error(f"The package {package_name} could not be detected")
         else:
             channels_list = []
             channels_present = False
@@ -165,7 +165,7 @@ class OperatorhubPackages(OcpBase):
                 if im.type == "AllNamespaces" and im.supported is True:
                     clusterwide_channels.append(channel)
         if len(clusterwide_channels) == 0:
-            logger.info("No clusterwide channels were found for package: {}".format(package_name))
+            logger.info(f"No clusterwide channels were found for package: {package_name}")
         return clusterwide_channels
 
     def get_package_multinamespace_channels(self, package_name: str) -> list:
@@ -185,7 +185,7 @@ class OperatorhubPackages(OcpBase):
                 if im.type == "MultiNamespace" and im.supported is True:
                     multinamespace_channels.append(channel)
         if len(multinamespace_channels) == 0:
-            logger.info("No MultiNamespace channels were found for package: {}".format(package_name))
+            logger.info(f"No MultiNamespace channels were found for package: {package_name}")
         return multinamespace_channels
 
     def get_package_singlenamespace_channels(self, package_name: str) -> list:
@@ -205,7 +205,7 @@ class OperatorhubPackages(OcpBase):
                 if im.type == "SingleNamespace" and im.supported is True:
                     singlenamespace_channels.append(channel)
         if len(singlenamespace_channels) == 0:
-            logger.info("No SingleNamespace channels were found for package: {}".format(package_name))
+            logger.info(f"No SingleNamespace channels were found for package: {package_name}")
         return singlenamespace_channels
 
     def get_package_ownnamespace_channels(self, package_name: str) -> list:
@@ -225,7 +225,7 @@ class OperatorhubPackages(OcpBase):
                 if im.type == "OwnNamespace" and im.supported is True:
                     ownnamespace_channels.append(channel)
         if len(ownnamespace_channels) == 0:
-            logger.info("No OwnNamespace channels were found for package: {}".format(package_name))
+            logger.info(f"No OwnNamespace channels were found for package: {package_name}")
         return ownnamespace_channels
 
     def get_package_default_channel(self, package_name: str) -> Optional[str]:
@@ -287,7 +287,7 @@ class OperatorSource(OcpBase):
     )
 
     def __init__(self, kube_config_file=None):
-        super(OperatorSource, self).__init__(kube_config_file=kube_config_file)
+        super().__init__(kube_config_file=kube_config_file)
         self.api_version = "operators.coreos.com/v1"
         self.kind = "OperatorSource"
         self.operator_source_obj = self.dyn_client.resources.get(api_version=self.api_version, kind=self.kind)
@@ -368,7 +368,7 @@ class CatalogSource(OcpBase):
     """
 
     def __init__(self, kube_config_file):
-        super(CatalogSource, self).__init__(kube_config_file=kube_config_file)
+        super().__init__(kube_config_file=kube_config_file)
         self.api_version = "operators.coreos.com/v1alpha1"
         self.kind = "CatalogSource"
         self.catalog_source_obj = self.dyn_client.resources.get(api_version=self.api_version, kind=self.kind)
@@ -448,10 +448,10 @@ class CatalogSource(OcpBase):
         :param return: (bool) A boolean value to indicate whether a catalog source is
                        present or not.
         """
-        field_selector = "metadata.name={}".format(cs_name)
+        field_selector = f"metadata.name={cs_name}"
         for event in self.catalog_source_obj.watch(namespace=namespace, field_selector=field_selector, timeout=timeout):
             if event["object"] and event["object"]["metadata"]["name"] == cs_name:
-                logger.info("CatalogSource {} in namescpace {} was found".format(cs_name, namespace))
+                logger.info(f"CatalogSource {cs_name} in namescpace {namespace} was found")
                 return True
         logger.warning(
             "CatalogSource {} in namespace {} was not detected within a timeout interval"
@@ -472,7 +472,7 @@ class Subscription(OcpBase):
     """
 
     def __init__(self, kube_config_file=None):
-        super(Subscription, self).__init__(kube_config_file=kube_config_file)
+        super().__init__(kube_config_file=kube_config_file)
         self.api_version = "operators.coreos.com/v1alpha1"
         self.kind = "Subscription"
         self.subscription_obj = self.dyn_client.resources.get(api_version=self.api_version, kind=self.kind)
@@ -547,7 +547,7 @@ class Subscription(OcpBase):
     def watch_subscription_ready(self, operator_name: str, namespace: str, timeout: int = 60) -> bool:
         logger.info("Watching %s subscription for readiness" % operator_name)
         is_operator_ready = False
-        field_selector = "metadata.name={}".format(operator_name)
+        field_selector = f"metadata.name={operator_name}"
         for event in self.subscription_obj.watch(namespace=namespace, field_selector=field_selector, timeout=timeout):
             for condition in event["object"]["status"]["conditions"]:
                 if condition["message"] == "all available catalogsources are healthy":
@@ -569,7 +569,7 @@ class OperatorGroup(OcpBase):
     """
 
     def __init__(self, kube_config_file=None):
-        super(OperatorGroup, self).__init__(kube_config_file=kube_config_file)
+        super().__init__(kube_config_file=kube_config_file)
         self.api_version = "operators.coreos.com/v1"
         self.kind = "OperatorGroup"
         self.operator_group_obj = self.dyn_client.resources.get(api_version=self.api_version, kind=self.kind)
@@ -659,7 +659,7 @@ class ClusterServiceVersion(OcpBase):
     """
 
     def __init__(self, kube_config_file=None):
-        super(ClusterServiceVersion, self).__init__(kube_config_file=kube_config_file)
+        super().__init__(kube_config_file=kube_config_file)
         self.api_version = "operators.coreos.com/v1alpha1"
         self.kind = "ClusterServiceVersion"
         self.csv_obj = self.dyn_client.resources.get(api_version=self.api_version, kind=self.kind)
@@ -694,10 +694,10 @@ class ClusterServiceVersion(OcpBase):
         :param return: (bool) A boolean value to indicate whether a catalog source is
                        present or not.
         """
-        field_selector = "metadata.name={}".format(csv_name)
+        field_selector = f"metadata.name={csv_name}"
         for event in self.csv_obj.watch(namespace=namespace, field_selector=field_selector, timeout=timeout):
             if event["object"] and event["object"]["metadata"]["name"] == csv_name:
-                logger.info("ClusterServiceVersion {} in namespace {} was found".format(csv_name, namespace))
+                logger.info(f"ClusterServiceVersion {csv_name} in namespace {namespace} was found")
                 return True
         logger.warning(
             "ClusterServiceVersion {} in namespace {} was not detected within a timeout interval"

--- a/piqe_ocp_lib/api/resources/ocp_pods.py
+++ b/piqe_ocp_lib/api/resources/ocp_pods.py
@@ -132,7 +132,7 @@ class OcpPods(OcpBase):
         """
         logger.info("Watching pod %s for readiness" % pod_name)
         pod_ready = False
-        field_selector = "metadata.name={}".format(pod_name)
+        field_selector = f"metadata.name={pod_name}"
         for event in self.ocp_pods.watch(namespace=namespace, field_selector=field_selector, timeout=timeout):
             for pod_condition in event["object"]["status"]["conditions"]:
                 if pod_condition["status"] == "True" and pod_condition["type"] == "Ready":

--- a/piqe_ocp_lib/api/resources/ocp_routes.py
+++ b/piqe_ocp_lib/api/resources/ocp_routes.py
@@ -17,7 +17,7 @@ class OcpRoutes(OcpBase):
     """
 
     def __init__(self, kube_config_file=None):
-        super(OcpRoutes, self).__init__(kube_config_file=kube_config_file)
+        super().__init__(kube_config_file=kube_config_file)
         self.api_version = "v1"
         self.kind = "Route"
         self.ocp_routes = self.dyn_client.resources.get(api_version=self.api_version, kind=self.kind)

--- a/piqe_ocp_lib/api/resources/ocp_secrets.py
+++ b/piqe_ocp_lib/api/resources/ocp_secrets.py
@@ -18,7 +18,7 @@ class OcpSecret(OcpBase):
     """
 
     def __init__(self, kube_config_file=None):
-        super(OcpSecret, self).__init__(kube_config_file=kube_config_file)
+        super().__init__(kube_config_file=kube_config_file)
         self.api_version = "v1"
         self.kind = "Secret"
         self.ocp_secret = self.dyn_client.resources.get(api_version=self.api_version, kind=self.kind)

--- a/piqe_ocp_lib/api/resources/ocp_service_accounts.py
+++ b/piqe_ocp_lib/api/resources/ocp_service_accounts.py
@@ -17,7 +17,7 @@ class OcpServiceAccount(OcpBase):
     """
 
     def __init__(self, kube_config_file=None):
-        super(OcpServiceAccount, self).__init__(kube_config_file=kube_config_file)
+        super().__init__(kube_config_file=kube_config_file)
         self.api_version = "v1"
         self.kind = "ServiceAccount"
         self.ocp_service_account = self.dyn_client.resources.get(api_version=self.api_version, kind=self.kind)

--- a/piqe_ocp_lib/api/tasks/operator_ops.py
+++ b/piqe_ocp_lib/api/tasks/operator_ops.py
@@ -1,11 +1,11 @@
 import logging
+from typing import List, Optional, Tuple, Union
 
 from kubernetes.client.rest import ApiException
-from typing import Union, Tuple, Optional, List
 
 from piqe_ocp_lib import __loggername__
-from piqe_ocp_lib.api.resources import OcpBase, OcpProjects
 from piqe_ocp_lib.api.ocp_exceptions import UnsupportedInstallMode
+from piqe_ocp_lib.api.resources import OcpBase, OcpProjects
 from piqe_ocp_lib.api.resources.ocp_operators import (
     ClusterServiceVersion,
     OperatorGroup,
@@ -34,7 +34,7 @@ class OperatorInstaller(OcpBase):
             3. If length is 1, we return 'SingleNamespace'.
             4. If length > 1, we return 'MultiNamespace'.
         """
-        if target_namespaces == '*':
+        if target_namespaces == "*":
             install_mode = "AllNamespaces"
         else:
             target_namespaces_count = len(target_namespaces)
@@ -58,10 +58,9 @@ class OperatorInstaller(OcpBase):
         assert self.proj_obj.create_a_namespace(operator_namespace)
         return operator_namespace
 
-    def _create_og(self, operator_name: str,
-                   channel_name: str,
-                   operator_namespace: str,
-                   target_namespaces: Union[list, str]) -> Tuple[str, str]:
+    def _create_og(
+        self, operator_name: str, channel_name: str, operator_namespace: str, target_namespaces: Union[list, str]
+    ) -> Tuple[str, str]:
         """
         A helper method that creates the operator group in the generated operator namespace
         """
@@ -76,10 +75,13 @@ class OperatorInstaller(OcpBase):
             assert self.og_obj.create_operator_group(og_name, operator_namespace, target_namespaces)
         return og_name, operator_namespace
 
-    def add_operator_to_cluster(self, operator_name: str,
-                                channel_name: str = '',
-                                operator_namespace: str = '',
-                                target_namespaces: Union[List[str], str] = []) -> bool:
+    def add_operator_to_cluster(
+        self,
+        operator_name: str,
+        channel_name: str = "",
+        operator_namespace: str = "",
+        target_namespaces: Union[List[str], str] = [],
+    ) -> bool:
         """
         Install an operator in a list of target namespaces
         :param operator_name: (required | str) The name of the operator to be installed

--- a/piqe_ocp_lib/api/tasks/operator_ops.py
+++ b/piqe_ocp_lib/api/tasks/operator_ops.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__loggername__)
 
 class OperatorInstaller(OcpBase):
     def __init__(self, kube_config_file: Optional[str] = None):
-        super(OperatorInstaller, self).__init__(kube_config_file=kube_config_file)
+        super().__init__(kube_config_file=kube_config_file)
         self.og_obj = OperatorGroup(kube_config_file=self.kube_config_file)
         self.sub_obj = Subscription(kube_config_file=self.kube_config_file)
         self.ohp_obj = OperatorhubPackages(kube_config_file=self.kube_config_file)

--- a/piqe_ocp_lib/api/tasks/populate_cluster/config_schemas.py
+++ b/piqe_ocp_lib/api/tasks/populate_cluster/config_schemas.py
@@ -11,7 +11,7 @@ from piqe_ocp_lib import __loggername__
 logger = logging.getLogger(__loggername__)
 
 
-class ocp_app(object):
+class ocp_app:
     """
     ocp_app class defines application's template, number of replicas and
     app_count of a ocp cluster
@@ -181,7 +181,7 @@ class ocp_app(object):
         self._app_params = app_params
 
 
-class ocp_project(object):
+class ocp_project:
     """ocp_project defines project in the ocp cluster i.e project_name
     and list of all apps of the project/namespace in ocp cluster.
     Each app in the projects list is of type 'ocp_app'
@@ -211,7 +211,7 @@ class ocp_project(object):
             apps = project.get("apps")
             if not isinstance(apps, self.ocp_project_config_types.get("apps")):
                 raise ValueError(
-                    "'apps': (Expected '%s', Actual '%s')" % (self.ocp_project_config_types["apps"], type(apps))
+                    "'apps': (Expected '{}', Actual '{}')".format(self.ocp_project_config_types["apps"], type(apps))
                 )
             else:
                 self._apps = []
@@ -294,7 +294,7 @@ class ocp_project(object):
         self._project_labels = project_labels
 
 
-class ocp_cluster_metadata(object):
+class ocp_cluster_metadata:
     """Class containing ocp cluster metadata"""
 
     ocp_cluster_metadata_types = {
@@ -488,7 +488,7 @@ class ocp_cluster_metadata(object):
         self._heketi = heketi
 
 
-class populate_ocp_cluster_config(object):
+class populate_ocp_cluster_config:
     """
     ocp_populate_cluster_config (dict): The key is attribute name
       and the value is attribute type.
@@ -516,7 +516,7 @@ class populate_ocp_cluster_config(object):
                 except Exception as yamlerror:
                     raise yaml.YAMLError("YAML Error:\n %s" % yamlerror)
         except Exception as ioerror:
-            raise IOError(ioerror)
+            raise OSError(ioerror)
 
         if cluster_config is None:
             raise ValueError("Invalid cluster config dict")
@@ -524,7 +524,7 @@ class populate_ocp_cluster_config(object):
         # get metadata
         cluster_metadata = cluster_config.get("metadata")
         if not isinstance(cluster_metadata, dict):
-            raise ValueError("'metadata': (Expected '%s', Actual '%s')" % (str(dict), type(cluster_metadata)))
+            raise ValueError(f"'metadata': (Expected '{str(dict)}', Actual '{type(cluster_metadata)}')")
         else:
             try:
                 self._metadata = ocp_cluster_metadata(cluster_metadata)

--- a/piqe_ocp_lib/api/tasks/populate_cluster/populate_cluster.py
+++ b/piqe_ocp_lib/api/tasks/populate_cluster/populate_cluster.py
@@ -230,7 +230,7 @@ class PopulateOcpCluster:
                 threads = list()
                 for project in filtered_projects:
                     thread = threading.Thread(
-                        target=populate, name="Thread_{}".format(project.project_name), args=(project,)
+                        target=populate, name=f"Thread_{project.project_name}", args=(project,)
                     )
                     threads.append(thread)
                     thread.start()

--- a/piqe_ocp_lib/api/tasks/populate_cluster/populate_cluster.py
+++ b/piqe_ocp_lib/api/tasks/populate_cluster/populate_cluster.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 import argparse
 from concurrent.futures import ThreadPoolExecutor
+import os
 import random
 from random import randint
 import sys
@@ -8,7 +9,6 @@ import threading
 from threading import Lock
 import time
 from time import sleep
-import os
 
 from piqe_ocp_lib import __loggername__
 from piqe_ocp_lib.api import ocp_exceptions
@@ -435,14 +435,12 @@ def argument_parser():
 
     # Define arguments
     parser = argparse.ArgumentParser(description="Process inputs for populate_ocp_cluster")
-    if 'PIQE_OCP_LIB_CLUSTER_CONF' in os.environ and os.environ['PIQE_OCP_LIB_CLUSTER_CONF']:
-        cfg_path = os.path.abspath(os.path.expandvars(os.path.expanduser(os.environ['PIQE_OCP_LIB_CLUSTER_CONF'])))
-        confopt = {'default': cfg_path}
+    if "PIQE_OCP_LIB_CLUSTER_CONF" in os.environ and os.environ["PIQE_OCP_LIB_CLUSTER_CONF"]:
+        cfg_path = os.path.abspath(os.path.expandvars(os.path.expanduser(os.environ["PIQE_OCP_LIB_CLUSTER_CONF"])))
+        confopt = {"default": cfg_path}
     else:
-        confopt = {'required': True}
-    parser.add_argument(
-        "-c", "--config", action="store", help="YAML Config file that describes the cluster", **confopt
-    )
+        confopt = {"required": True}
+    parser.add_argument("-c", "--config", action="store", help="YAML Config file that describes the cluster", **confopt)
     parser.add_argument(
         "-d",
         "--debug",

--- a/piqe_ocp_lib/piqe_api_logger.py
+++ b/piqe_ocp_lib/piqe_api_logger.py
@@ -52,12 +52,12 @@ FILENAME = "piqe_api_logger_{}.log".format(datetime.now().strftime("%Y_%m_%d_%H_
 FILEPATH = os.path.join(LOG_DIR, FILENAME)
 
 
-class piqe_api_logger(object):
+class piqe_api_logger:
     _logger = None
 
     def __new__(cls, *args, **kwargs):
         if cls._logger is None:
-            cls._logger = super(piqe_api_logger, cls).__new__(cls)
+            cls._logger = super().__new__(cls)
             # Put any initialization here.
             cls._logger = logging.getLogger(args[0])
             cls._logger.setLevel(logging.DEBUG)

--- a/piqe_ocp_lib/tests/conftest.py
+++ b/piqe_ocp_lib/tests/conftest.py
@@ -8,8 +8,8 @@ from glusto.core import Glusto as g
 import pytest
 
 from piqe_ocp_lib import __loggername__
-from piqe_ocp_lib.piqe_api_logger import piqe_api_logger
 from piqe_ocp_lib.api.resources.ocp_cluster_operators import OcpClusterOperator
+from piqe_ocp_lib.piqe_api_logger import piqe_api_logger
 
 
 def pytest_addoption(parser):

--- a/piqe_ocp_lib/tests/resources/test_ocp_apps.py
+++ b/piqe_ocp_lib/tests/resources/test_ocp_apps.py
@@ -23,7 +23,7 @@ def setup_params(get_kubeconfig):
     return params_dict
 
 
-class TestOcpApps(object):
+class TestOcpApps:
     def test_create_app_from_template(self, setup_params):
         """
         1. Create a test project

--- a/piqe_ocp_lib/tests/resources/test_ocp_base.py
+++ b/piqe_ocp_lib/tests/resources/test_ocp_base.py
@@ -9,7 +9,7 @@ from piqe_ocp_lib.api.resources.ocp_base import Version
 logger = logging.getLogger(__loggername__)
 
 
-class TestOcpBase(object):
+class TestOcpBase:
     def test_init(self, get_kubeconfig):
         base_api_obj = OcpBase(kube_config_file=get_kubeconfig)
         assert base_api_obj.kube_config_file is not None

--- a/piqe_ocp_lib/tests/resources/test_ocp_nodes.py
+++ b/piqe_ocp_lib/tests/resources/test_ocp_nodes.py
@@ -15,7 +15,7 @@ def setup_params(get_kubeconfig):
     return params_dict
 
 
-class TestOcpNodes(object):
+class TestOcpNodes:
     def test_get_all_nodes(self, setup_params):
         """
         Verify that a list of all nodes is returned
@@ -28,7 +28,7 @@ class TestOcpNodes(object):
         # Get all nodes
         api_response = node_api_obj.get_all_nodes()
         node_count = len(api_response.items)
-        logger.info("{} nodes returned in the list".format(node_count))
+        logger.info(f"{node_count} nodes returned in the list")
         assert api_response.kind == "NodeList"
 
         # Get nodes matching a single label
@@ -36,7 +36,7 @@ class TestOcpNodes(object):
         list_items_single_label = len(api_response.items)
         # All nodes are expected to have this label, validate that the list counts match.
         assert list_items_single_label == node_count
-        logger.info("{} nodes matched the provided label".format(list_items_single_label))
+        logger.info(f"{list_items_single_label} nodes matched the provided label")
         assert api_response.kind == "NodeList"
         # Get nodes matching 2 labels
         api_response = node_api_obj.get_all_nodes(
@@ -45,7 +45,7 @@ class TestOcpNodes(object):
         list_items_two_labels = len(api_response.items)
         # All nodes are expected to have these labels, validate that the list counts match.
         assert list_items_two_labels == node_count
-        logger.info("{} nodes matched the provided label".format(list_items_two_labels))
+        logger.info(f"{list_items_two_labels} nodes matched the provided label")
         assert api_response.kind == "NodeList"
 
     def test_get_all_node_names(self, setup_params):
@@ -59,7 +59,7 @@ class TestOcpNodes(object):
         node_api_obj = setup_params["node_api_obj"]
         api_response = node_api_obj.get_all_node_names()
         assert type(api_response) is list
-        logger.info("Node name list: {}".format(api_response))
+        logger.info(f"Node name list: {api_response}")
         assert len(api_response) > 0
 
     def test_get_a_node(self, setup_params):
@@ -74,7 +74,7 @@ class TestOcpNodes(object):
         api_response_node_name_list = node_api_obj.get_all_node_names()
         number_of_nodes = len(api_response_node_name_list)
         assert number_of_nodes > 0
-        logger.info("{} Nodes returned".format(number_of_nodes))
+        logger.info(f"{number_of_nodes} Nodes returned")
         for node_name in api_response_node_name_list:
             # Use each node name from the list to get_a_node by mane.
             api_response = node_api_obj.get_a_node(node_name=node_name)
@@ -119,11 +119,11 @@ class TestOcpNodes(object):
         for node_name in api_response_node_name_list:
             # Use each node name from the list to get the node status by name
             api_response_node_roles = node_api_obj.get_node_roles(node_name=node_name)
-            logger.info("Retrieved {} roles for node {}".format(api_response_node_roles, node_name))
+            logger.info(f"Retrieved {api_response_node_roles} roles for node {node_name}")
             number_of_roles = len(api_response_node_roles)
             assert number_of_roles >= 1
             for role in api_response_node_roles:
-                logger.info("Node name: {} Role: {}".format(node_name, role))
+                logger.info(f"Node name: {node_name} Role: {role}")
                 assert role == "Master" or role == "Worker"
 
     def test_label_a_node(self, setup_params):
@@ -145,7 +145,7 @@ class TestOcpNodes(object):
             assert api_response.metadata.name == node_name
             # Label the node
             node_label = {"test.label.node": "true"}
-            logger.info("Label the Node with {}".format(node_label))
+            logger.info(f"Label the Node with {node_label}")
             label_api_response = node_api_obj.label_a_node(node_name=node_name, labels=node_label)
             assert label_api_response.kind == "Node"
             assert label_api_response.metadata.name == node_name
@@ -153,14 +153,14 @@ class TestOcpNodes(object):
             labelled_node_api_response = node_api_obj.get_all_nodes(
                 label_selector="test.label.node=true," "kubernetes.io/hostname=" + node_name
             )
-            logger.info("Retrieved the node by labels {}".format(labelled_node_api_response.items[0].metadata.name))
+            logger.info(f"Retrieved the node by labels {labelled_node_api_response.items[0].metadata.name}")
             assert len(labelled_node_api_response.items) == 1
             assert labelled_node_api_response.items[0].metadata.name == node_name
-            logger.info("Retrieved the node by labels {}".format(labelled_node_api_response.items[0].metadata.name))
+            logger.info(f"Retrieved the node by labels {labelled_node_api_response.items[0].metadata.name}")
             # Evaluate Use addresses list to find the type Hostname
             for address in labelled_node_api_response.items[0].status.addresses:
                 if address.type == "Hostname":
-                    logger.info("Address Type: {}  Address: {}".format(address.type, address.address))
+                    logger.info(f"Address Type: {address.type}  Address: {address.address}")
                     # Validate that the node name is the same as the hostname for the node.
                     assert address.address == node_name
 
@@ -193,7 +193,7 @@ class TestOcpNodes(object):
             api_response = node_api_obj.get_a_node(node_name=node_name)
             assert api_response.kind == "Node"
             assert api_response.metadata.name == node_name
-            logger.info("Execute command on Node {}".format(node_name))
+            logger.info(f"Execute command on Node {node_name}")
             command_api_response = node_api_obj.execute_command_on_a_node(
                 node_name=node_name, command_to_execute="whoami"
             )
@@ -205,14 +205,14 @@ class TestOcpNodes(object):
             assert command_api_response[1] == expected_stdout
             assert command_api_response[2] == expected_stderr
             decoded_str = command_api_response[1].decode("utf-8")
-            logger.info("Decoded stdout string {}".format(decoded_str))
+            logger.info(f"Decoded stdout string {decoded_str}")
 
         # Validate stderr
         for node_name in api_response_node_name_list:
             api_response = node_api_obj.get_a_node(node_name=node_name)
             assert api_response.kind == "Node"
             assert api_response.metadata.name == node_name
-            logger.info("Execute command on Node {}".format(node_name))
+            logger.info(f"Execute command on Node {node_name}")
             command_api_response = node_api_obj.execute_command_on_a_node(
                 node_name=node_name, command_to_execute="bogus"
             )
@@ -222,5 +222,5 @@ class TestOcpNodes(object):
             assert command_api_response[1] == expected_stdout
             assert type(command_api_response[2]) is bytes
             decoded_str = command_api_response[2].decode("utf-8")
-            logger.info("Decoded stderr string {}".format(decoded_str))
+            logger.info(f"Decoded stderr string {decoded_str}")
             assert decoded_str.find("executable file not found in $PATH") >= 1

--- a/piqe_ocp_lib/tests/resources/test_ocp_operators.py
+++ b/piqe_ocp_lib/tests/resources/test_ocp_operators.py
@@ -9,11 +9,11 @@ import pytest
 from piqe_ocp_lib import __loggername__
 from piqe_ocp_lib.api.resources import OcpProjects
 from piqe_ocp_lib.api.resources.ocp_operators import (
+    CatalogSource,
     ClusterServiceVersion,
     OperatorGroup,
     OperatorhubPackages,
     OperatorSource,
-    CatalogSource,
     Subscription,
 )
 from piqe_ocp_lib.api.tasks.operator_ops import OperatorInstaller
@@ -109,7 +109,7 @@ class TestOcpOperatorHub:
     def test_get_channel_suggested_namespace(self, get_test_objects):
         pkg_obj = get_test_objects.op_hub_obj
         expected_namespace = "openshift-cnv"
-        suggested_namespace = pkg_obj.get_channel_suggested_namespace('kubevirt-hyperconverged', 'stable')
+        suggested_namespace = pkg_obj.get_channel_suggested_namespace("kubevirt-hyperconverged", "stable")
         assert expected_namespace == suggested_namespace
 
     def test_get_package_allnamespaces_channels(self, get_test_objects):
@@ -144,12 +144,12 @@ class TestOcpOperatorHub:
 
     def test_get_crd_models_from_manifest(self, get_test_objects):
         cmfm_obj = get_test_objects.op_hub_obj
-        alm_list = cmfm_obj.get_crd_models_from_manifest('amq-streams', 'stable')
+        alm_list = cmfm_obj.get_crd_models_from_manifest("amq-streams", "stable")
         assert len(alm_list) != 0
         for i in range(0, len(alm_list)):
-            assert 'apiVersion' in alm_list[i].keys()
+            assert "apiVersion" in alm_list[i].keys()
         for i in range(0, len(alm_list)):
-            assert 'kind' in alm_list[i].keys()
+            assert "kind" in alm_list[i].keys()
 
     def test_get_package_default_channel(self, get_test_objects):
         pkg_obj = get_test_objects.op_hub_obj
@@ -199,7 +199,7 @@ class TestOperatorSource:
 
 
 class TestCatalogSource:
-    cs_name = 'test-'+'-'+''.join(random.choice(string.ascii_lowercase) for i in range(4))
+    cs_name = "test-" + "-" + "".join(random.choice(string.ascii_lowercase) for i in range(4))
 
     def test_create_catalog_source(self, get_test_objects):
         image = "quay.io/openshift-qe-optional-operators/ocp4-index:latest"
@@ -229,7 +229,7 @@ class TestSubscription:
         # Create a subscription and check kind and name
         # for correctness
         get_test_objects.project_obj.create_a_project("test-project1")
-        nfd_default_channel = get_test_objects.op_hub_obj.get_package_default_channel('nfd')
+        nfd_default_channel = get_test_objects.op_hub_obj.get_package_default_channel("nfd")
         sub_resp_obj = get_test_objects.sub_obj.create_subscription("nfd", nfd_default_channel, "test-project1")
         assert sub_resp_obj.kind == "Subscription" and sub_resp_obj.metadata.name == "nfd"
 
@@ -329,42 +329,42 @@ class TestInstallOperatorWorkflow:
     of an operator is implemented, and this test will be updated.
     """
 
-    def test_add_random_operator_using_default_channel(self, project_resource,
-                                                       operator_installer,
-                                                       operator_hub,
-                                                       cluster_service):
-        pkg_list = operator_hub.get_package_manifest_list(catalog='redhat-operators')
+    def test_add_random_operator_using_default_channel(
+        self, project_resource, operator_installer, operator_hub, cluster_service
+    ):
+        pkg_list = operator_hub.get_package_manifest_list(catalog="redhat-operators")
         rand_pkg = random.choice(pkg_list.items)
         operator = rand_pkg.metadata.name
         default_channel = operator_hub.get_package_default_channel(operator)
-        if not operator_hub.is_install_mode_supported_by_channel(operator, default_channel, 'OwnNamespace'):
-            logger.info(f"""Channel {default_channel} for Operator {operator} does not support
-                            install mode 'OwnNamespace' ... skipping test.""")
+        if not operator_hub.is_install_mode_supported_by_channel(operator, default_channel, "OwnNamespace"):
+            logger.info(
+                f"""Channel {default_channel} for Operator {operator} does not support
+                            install mode 'OwnNamespace' ... skipping test."""
+            )
             return
         else:
             operator_installer.add_operator_to_cluster(operator)
             operator_namespace = operator_hub.get_channel_suggested_namespace(rand_pkg.metadata.name, default_channel)
             if not operator_namespace:
-                operator_namespace = f'openshift-{rand_pkg.metadata.name}'
+                operator_namespace = f"openshift-{rand_pkg.metadata.name}"
             csv_name = operator_hub.get_package_channel_by_name(rand_pkg.metadata.name, default_channel).currentCSV
             assert cluster_service.is_cluster_service_version_present(csv_name, operator_namespace, timeout=120)
             # TODO: update when delete_operator_from_cluster is implemented
             project_resource.delete_a_project(operator_namespace)
 
     def test_add_operator_ownnamespace(self, project_resource, operator_installer, operator_hub, cluster_service):
-        operator_installer.add_operator_to_cluster("amq-streams", 'stable', 'test-ownnamespace')
-        csv_name = operator_hub.get_package_channel_by_name('amq-streams', 'stable').currentCSV
+        operator_installer.add_operator_to_cluster("amq-streams", "stable", "test-ownnamespace")
+        csv_name = operator_hub.get_package_channel_by_name("amq-streams", "stable").currentCSV
         assert cluster_service.is_cluster_service_version_present(csv_name, "test-ownnamespace")
         # TODO: update when delete_operator_from_cluster is implemented
         project_resource.delete_a_project("test-ownnamespace")
 
     def test_add_operator_singlenamespace(self, project_resource, operator_installer, operator_hub, cluster_service):
         project_resource.create_a_project("test-project4")
-        operator_installer.add_operator_to_cluster("amq-streams",
-                                                   'stable',
-                                                   'test-singlenamespace',
-                                                   target_namespaces=["test-project4"])
-        csv_name = operator_hub.get_package_channel_by_name('amq-streams', 'stable').currentCSV
+        operator_installer.add_operator_to_cluster(
+            "amq-streams", "stable", "test-singlenamespace", target_namespaces=["test-project4"]
+        )
+        csv_name = operator_hub.get_package_channel_by_name("amq-streams", "stable").currentCSV
         assert cluster_service.is_cluster_service_version_present(csv_name, "test-project4")
         # TODO: update when delete_operator_from_cluster is implemented
         project_resource.delete_a_project("test-singlenamespace")
@@ -373,12 +373,11 @@ class TestInstallOperatorWorkflow:
     def test_add_operator_multinamespace(self, project_resource, operator_installer, operator_hub, cluster_service):
         project_resource.create_a_project("test-project5")
         project_resource.create_a_project("test-project6")
-        operator_installer.add_operator_to_cluster("amq-streams",
-                                                   'stable',
-                                                   'test-multinamespace',
-                                                   target_namespaces=["test-project5", "test-project6"])
+        operator_installer.add_operator_to_cluster(
+            "amq-streams", "stable", "test-multinamespace", target_namespaces=["test-project5", "test-project6"]
+        )
 
-        csv_name = operator_hub.get_package_channel_by_name('amq-streams', 'stable').currentCSV
+        csv_name = operator_hub.get_package_channel_by_name("amq-streams", "stable").currentCSV
 
         # increased timeout because on slow virtual clusters the default 30 seconds may not be enough
         assert cluster_service.is_cluster_service_version_present(csv_name, "test-project5", timeout=60)
@@ -390,8 +389,8 @@ class TestInstallOperatorWorkflow:
         project_resource.delete_a_project("test-project6")
 
     def test_add_operator_clusterwide(self, project_resource, operator_installer, operator_hub, cluster_service):
-        operator_installer.add_operator_to_cluster("amq-streams", 'stable', 'test-clusterwide', target_namespaces='*')
-        csv_name = operator_hub.get_package_channel_by_name('amq-streams', 'stable').currentCSV
+        operator_installer.add_operator_to_cluster("amq-streams", "stable", "test-clusterwide", target_namespaces="*")
+        csv_name = operator_hub.get_package_channel_by_name("amq-streams", "stable").currentCSV
         all_projects = project_resource.get_all_projects()
 
         for project in all_projects.items:

--- a/piqe_ocp_lib/tests/resources/test_ocp_operators.py
+++ b/piqe_ocp_lib/tests/resources/test_ocp_operators.py
@@ -119,7 +119,7 @@ class TestOcpOperatorHub:
         pkg_obj = get_test_objects.op_hub_obj
         pkg_list = pkg_obj.get_package_manifest_list()
         rand_pkg = random.choice(pkg_list.items)
-        logger.info("Package name is: {}".format(rand_pkg.metadata.name))
+        logger.info(f"Package name is: {rand_pkg.metadata.name}")
         cluster_wide_channels = pkg_obj.get_package_allnamespaces_channels(rand_pkg.metadata.name)
         if cluster_wide_channels:
             assert cluster_wide_channels[0]["currentCSVDesc"]["installModes"][3]["type"] == "AllNamespaces"
@@ -134,7 +134,7 @@ class TestOcpOperatorHub:
         pkg_obj = get_test_objects.op_hub_obj
         pkg_list = pkg_obj.get_package_manifest_list()
         rand_pkg = random.choice(pkg_list.items)
-        logger.info("Package name is: {}".format(rand_pkg.metadata.name))
+        logger.info(f"Package name is: {rand_pkg.metadata.name}")
         single_namespace_channels = pkg_obj.get_package_singlenamespace_channels(rand_pkg.metadata.name)
         if single_namespace_channels:
             assert single_namespace_channels[0]["currentCSVDesc"]["installModes"][1]["type"] == "SingleNamespace"

--- a/piqe_ocp_lib/tests/resources/test_ocp_projects.py
+++ b/piqe_ocp_lib/tests/resources/test_ocp_projects.py
@@ -20,7 +20,7 @@ def setup_params(get_kubeconfig):
     return params_dict
 
 
-class TestOcpProjects(object):
+class TestOcpProjects:
     def test_create_a_project(self, setup_params):
         """
         1. Create a test project

--- a/piqe_ocp_lib/tests/resources/test_ocp_secrets.py
+++ b/piqe_ocp_lib/tests/resources/test_ocp_secrets.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__loggername__)
 
 five_digit_number = "".join(random.sample("0123456789", 5))
 NAMESPACE = "default"
-SA_TOKEN_NAME = "test-sa-token-{}".format(five_digit_number)
+SA_TOKEN_NAME = f"test-sa-token-{five_digit_number}"
 SA_TOKEN = (
     "ZXlKaGJHY2lPaUpTVXpJMU5pSXNJbXRwWkNJNklpSjkuZXlKcGMzTWlPaUpyZFdKbGNtNWxkR1Z6TDNObGNuWnBZMlZoWT"
     "JOdmRXNTBJaXdpYTNWaVpYSnVaWFJsY3k1cGJ5OXpaWEoyYVdObFlXTmpiM1Z1ZEM5dVlXMWxjM0JoWTJVaU9pSnZjR1Z1"
@@ -54,7 +54,7 @@ class TestOcpSecrets:
         ):
             logger.info("Secret token created successfully")
         else:
-            assert False, "Failed to create {} service access secret token".format(SA_TOKEN_NAME)
+            assert False, f"Failed to create {SA_TOKEN_NAME} service access secret token"
 
     def test_get_secret_token(self, ocp_secret):
         secret_token = ocp_secret.get_secret_token(secret_name=SA_TOKEN_NAME, namespace=NAMESPACE)

--- a/piqe_ocp_lib/tests/resources/test_ocp_services.py
+++ b/piqe_ocp_lib/tests/resources/test_ocp_services.py
@@ -30,7 +30,7 @@ def ocp_app(get_kubeconfig) -> OcpApps:
 def httpd_template() -> str:
     path = Path(__file__).parent / "templates/httpd.json"
 
-    with open(path, "r") as file:
+    with open(path) as file:
         yield json.load(file)
 
 

--- a/piqe_ocp_lib/tests/resources/test_ocp_templates.py
+++ b/piqe_ocp_lib/tests/resources/test_ocp_templates.py
@@ -21,7 +21,7 @@ def setup_params(get_kubeconfig):
     return params_dict
 
 
-class TestOcpTemplates(object):
+class TestOcpTemplates:
     def __setup(self, setup_params):
         """
         Creates a project required by all tests.
@@ -31,7 +31,7 @@ class TestOcpTemplates(object):
         project_api_obj = setup_params["project_api_obj"]
         api_response = project_api_obj.create_a_project(setup_params["test_project"])
         assert api_response.metadata.name == setup_params["test_project"]
-        logger.info("Project : {}, succesfully created".format(api_response.metadata.name))
+        logger.info(f"Project : {api_response.metadata.name}, succesfully created")
 
     def __cleanup(self, setup_params):
         """
@@ -69,7 +69,7 @@ class TestOcpTemplates(object):
         api_response = template_api_obj.create_a_template_in_a_namespace(body, project=setup_params["test_project"])
         assert api_response.kind == "Template"
         assert api_response.metadata.name == setup_params["app_name"]
-        logger.info("API Response kind : {}, Name: {}".format(api_response.kind, api_response.metadata.name))
+        logger.info(f"API Response kind : {api_response.kind}, Name: {api_response.metadata.name}")
 
         #
         # Cleanup
@@ -132,7 +132,7 @@ class TestOcpTemplates(object):
         api_response = template_api_obj.get_all_templates_in_a_namespace(project=setup_params["test_project"])
         assert api_response.kind == "TemplateList"
         assert api_response.items[0].metadata.name == setup_params["app_name"]
-        logger.info("API Response kind : {}, Name: {}".format(api_response.kind, api_response.items[0].metadata.name))
+        logger.info(f"API Response kind : {api_response.kind}, Name: {api_response.items[0].metadata.name}")
 
         #
         # Cleanup

--- a/piqe_ocp_lib/tests/resources/test_ocp_virtual_machine.py
+++ b/piqe_ocp_lib/tests/resources/test_ocp_virtual_machine.py
@@ -10,7 +10,8 @@ from piqe_ocp_lib.api.resources.ocp_virtual_machine import (
     VirtualMachineSubResourcesClient,
 )
 
-pytestmark = pytest.mark.requiresoperator('kubevirt-hyperconverged')
+pytestmark = pytest.mark.requiresoperator("kubevirt-hyperconverged")
+
 
 @pytest.fixture(scope="module")
 def vm_name() -> str:

--- a/piqe_ocp_lib/tests/tasks/test_populate_ocp.py
+++ b/piqe_ocp_lib/tests/tasks/test_populate_ocp.py
@@ -25,14 +25,14 @@ def populate_ocp_cluster(ocp_smoke_args):
         # support a library specific variable than use WORKSPACE
         # since in the Jenkins context WORKSPACE doesn't necessarily mean the
         # PWD which can lead to trouble
-        cluster_config = os.path.abspath(os.path.expandvars(os.path.expanduser(os.environ['PIQE_OCP_LIB_CLUSTER_CONF'])
-                                                            )
-                                         )
-    elif os.path.exists(os.path.join('/'.join(__file__.split(os.sep)[:-2]), 'config/', 'smoke_ocp_config.yaml')):
+        cluster_config = os.path.abspath(
+            os.path.expandvars(os.path.expanduser(os.environ["PIQE_OCP_LIB_CLUSTER_CONF"]))
+        )
+    elif os.path.exists(os.path.join("/".join(__file__.split(os.sep)[:-2]), "config/", "smoke_ocp_config.yaml")):
         # This is a reliable way to default to finding the ocp_config.yml in the test/config directory
         # by working our way up the parent directory from the location of this test file rather
         # than relying on the on the WORKSPACE env and assuming the relative path.
-        cluster_config = os.path.join('/'.join(__file__.split(os.sep)[:-2]), 'config/', 'smoke_ocp_config.yaml')
+        cluster_config = os.path.join("/".join(__file__.split(os.sep)[:-2]), "config/", "smoke_ocp_config.yaml")
     else:
         raise ValueError(
             "A path to the cluster config yaml was expected, or a PIQE_OCP_LIB_CLUSTER_CONF env variable"
@@ -108,14 +108,15 @@ class TestOperatorInstaller:
 
     def test_is_operator_installed(self, get_kubeconfig):
         verify = OperatorInstaller(get_kubeconfig)
-        assert verify.is_operator_installed('packageserver', 'openshift-operator-lifecycle-manager') is True
+        assert verify.is_operator_installed("packageserver", "openshift-operator-lifecycle-manager") is True
 
     @pytest.mark.unit
     @mock.patch.object(Subscription, "get_subscription")
     @mock.patch.object(Subscription, "delete_subscription", side_effect=[ApiException])
     @mock.patch.object(ClusterServiceVersion, "delete_cluster_service_version")
-    def test_delete_operator_from_cluster_failed_to_delete_sub(self, _mock_delete, _mock_del_sub, mock_get_sub,
-                                                               get_kubeconfig, caplog):
+    def test_delete_operator_from_cluster_failed_to_delete_sub(
+        self, _mock_delete, _mock_del_sub, mock_get_sub, get_kubeconfig, caplog
+    ):
         caplog.set_level(logging.ERROR)
 
         expected_operator_name = "foo-name"


### PR DESCRIPTION
- CSSWA-291: run pyupgrade --py36-plus
```
    drop old python2 code after confirming that only >=py36 is supported

    - https://github.com/asottile/pyupgrade#redundant-open-modes
    - https://github.com/asottile/pyupgrade#-coding--comment
    - https://github.com/asottile/pyupgrade#super-calls
    - https://github.com/asottile/pyupgrade#rewrites-class-declaration
    - https://github.com/asottile/pyupgrade#forced-strnative-literals
    - https://github.com/asottile/pyupgrade#unpacking-argument-list-comprehensions
    - https://github.com/asottile/pyupgrade#f-strings
    - https://github.com/asottile/pyupgrade#printf-style-string-formatting

    to reproduce these changes run `pyupgrade --py36-plus` on all files
```

- run `make format`

I have intentionally left these as two separate commits, please do not squash them.