### PR TITLE
CSSWA-531: fix AttributeError during longevity test

### DIFF
--- a/piqe_ocp_lib/tests/tasks/test_populate_ocp.py
+++ b/piqe_ocp_lib/tests/tasks/test_populate_ocp.py
@@ -61,7 +61,7 @@ class TestPopulateOcpCluster:
                 ocp_smoke_args.span, scale_replicas=ocp_smoke_args.replicas
             )
         except Exception as e:
-            logger.error("Exception while running longevity: %s", e.message)
+            logger.error("Exception while running longevity: %s", str(e))
         logger.info("Is longevity completed successfully? : %s", is_longevity_successful)
         assert is_longevity_successful is True
 


### PR DESCRIPTION
`TestPopulateOcpCluster.test_ocp_longevity` is failing at the test level
due to an `AttributeError` which can be easily fixed and get the error
back to failing on the proper assertion.

before:
```
    @pytest.mark.longevity
    def test_ocp_longevity(self, populate_ocp_cluster, ocp_smoke_args):
        """ Testcase to test if running longevity tests on existing cluster is successful """
        is_longevity_successful = False
        try:
            is_longevity_successful = populate_ocp_cluster.longevity(
                ocp_smoke_args.span, scale_replicas=ocp_smoke_args.replicas
            )
        except Exception as e:
>           logger.error("Exception while running longevity: %s", e.message)
E           AttributeError: 'ExecutionError' object has no attribute 'message'
piqe_ocp_lib/tests/tasks/test_populate_ocp.py:64: AttributeError
```

after:
```
    @pytest.mark.longevity
    def test_ocp_longevity(self, populate_ocp_cluster, ocp_smoke_args):
        """ Testcase to test if running longevity tests on existing cluster is successful """
        is_longevity_successful = False
        try:
            is_longevity_successful = populate_ocp_cluster.longevity(
                ocp_smoke_args.span, scale_replicas=ocp_smoke_args.replicas
            )
        except Exception as e:
            logger.error("Exception while running longevity: %s", str(e))
        logger.info("Is longevity completed successfully? : %s", is_longevity_successful)
>       assert is_longevity_successful is True
E       assert False is True
piqe_ocp_lib/tests/tasks/test_populate_ocp.py:66: AssertionError
```
