### PR TITLE
CSSWA-531: fix AttributeError in ocp_operators tests

### DIFF
--- a/piqe_ocp_lib/api/resources/ocp_operators.py
+++ b/piqe_ocp_lib/api/resources/ocp_operators.py
@@ -61,13 +61,11 @@ class OperatorhubPackages(OcpBase):
             package_obj = self.package_manifest_obj.get(field_selector="metadata.name={}".format(package_name))
         except ApiException as e:
             logger.exception("Exception when calling method get_package_manifest: %s\n" % e)
-        if package_obj and len(package_obj.items) == 1:
+        if package_obj and len(package_obj.items) >= 1:
             return package_obj.items[0]
-        elif len(package_obj.items) == 0:
+        else:
             logger.exception("The package {}, could not be detected".format(package_name))
             return None
-        else:
-            return package_obj.items
 
     def watch_package_manifest_present(self, package_name, timeout=30):
         """


### PR DESCRIPTION
according to the docstring, `get_package_manifest` should only return a
single `PackageManifest` object, or None.

before:
```
――――――――――――――――――――――――――――――――――
TestOcpOperatorHub.test_get_package_singlenamespace_channel
―――――――――――――――――――――――――――――――――――

self = <piqe_ocp_lib.tests.resources.test_ocp_operators.TestOcpOperatorHub object at 0x7f5ccc0ac070>
get_test_objects =
<piqe_ocp_lib.tests.resources.test_ocp_operators.get_test_objects.<locals>.TestObjects
 object at 0x7f5ccc3864f0>

    def test_get_package_singlenamespace_channel(self, get_test_objects):
        # We pick a random package and check wether it has a singlenamespace channel
        # If it does, we check that the 2nd object in the install modes list
        # is of type 'SingleNamespace' and that it is supported
        pkg_obj = get_test_objects.op_hub_obj
        pkg_list = pkg_obj.get_package_manifest_list()
        rand_pkg = random.choice(pkg_list.items)
        logger.info("Package name is: {}".format(rand_pkg.metadata.name))
>       single_namespace_channel = pkg_obj.get_package_singlenamespace_channel(rand_pkg.metadata.name)

piqe_ocp_lib/tests/resources/test_ocp_operators.py:122:
 _ _ _ _ _ _ _ _ _
piqe_ocp_lib/api/resources/ocp_operators.py:168: in get_package_singlenamespace_channel
    channels_list = self.get_package_channels_list(package_name)
 _ _ _ _ _ _ _ _ _

self = <piqe_ocp_lib.api.resources.ocp_operators.OperatorhubPackages object at 0x7f5ccc386550>
package_name = 'local-storage-operator'

    def get_package_channels_list(self, package_name):
        """
        A method that returns a list of available subscription channels for a particular
        package. Different channels maps to one or more install modes.
        :param package_name: The name of the operator package for which we want to obtain
                             the supported channels list.
        :return: A list of subscription channels.
        """
        if not self.watch_package_manifest_present(package_name):
            logger.error("The package {} could not be detected".format(package_name))
        else:
            channels_list = []
            channels_present = False
            while not channels_present:
                try:
                    resp = self.get_package_manifest(package_name=package_name)
>                   if resp.status and resp.status.channels:
E                   AttributeError: 'list' object has no attribute 'status'

piqe_ocp_lib/api/resources/ocp_operators.py:107: AttributeError
```

after:
```
 piqe_ocp_lib/tests/resources/test_ocp_operators.py ✓✓✓✓✓
 ...
Results (3.84s):
       5 passed
```
