### PR TITLE
Fix gh actions lint leaking again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,7 @@ format:
 	poetry run black piqe_ocp_lib/
 
 lint:
-	poetry run flake8 piqe_ocp_lib/*; \
-	poetry run black --check --diff piqe_ocp_lib/; \
-	poetry run isort --check-only --diff piqe_ocp_lib/
+	chmod +x lint_check && ./lint_check
 
 test:
 	poetry run pytest

--- a/lint_check
+++ b/lint_check
@@ -1,0 +1,23 @@
+#!/bin/bash
+# quick script to allow us to run the poetry lint commands together without having
+# Make bomb out on the first poetry command without running the others or getting
+# complicated with the CI github actions with a job for each lint tool.
+
+LINT_RC=0
+
+poetry run flake8 piqe_ocp_lib/*
+if [ $? -eq 1 ] && [ $LINT_RC -eq 0 ]; then
+  LINT_RC=1
+fi
+
+poetry run black --check --diff piqe_ocp_lib/
+if [ $? -eq 1 ] && [ $LINT_RC -eq 0 ]; then
+  LINT_RC=1
+fi
+
+poetry run isort --check-only --diff piqe_ocp_lib/
+if [ $? -eq 1 ] && [ $LINT_RC -eq 0 ]; then
+  LINT_RC=1
+fi
+
+exit $LINT_RC


### PR DESCRIPTION
 * Missed a corner case, so decided to wrap in a
   simple bash script that allows running all
   linting tools without having Make fail prematurely
   or overly complicate the GH action jobs