### PR TITLE
CSSWA-538 Create global fixture for cleaning up test artifacts

### DIFF
--- a/piqe_ocp_lib/api/resources/ocp_projects.py
+++ b/piqe_ocp_lib/api/resources/ocp_projects.py
@@ -1,6 +1,8 @@
 import logging
+from typing import Optional
 
 from kubernetes.client.rest import ApiException
+from openshift.dynamic.resource import ResourceInstance
 
 from piqe_ocp_lib import __loggername__
 
@@ -17,14 +19,14 @@ class OcpProjects(OcpBase):
     :return: None
     """
 
-    def __init__(self, kube_config_file=None):
+    def __init__(self, kube_config_file: Optional[str] = None):
         self.kube_config_file = kube_config_file
         OcpBase.__init__(self, kube_config_file=self.kube_config_file)
         self.api_version = "v1"
         self.ocp_projects = self.dyn_client.resources.get(api_version=self.api_version, kind="Namespace")
         self.create_ocp_projects = self.dyn_client.resources.get(api_version=self.api_version, kind="ProjectRequest")
 
-    def create_a_project(self, project_name, labels_dict=None):
+    def create_a_project(self, project_name: str, labels_dict: Optional[dict] = None) -> Optional[ResourceInstance]:
         """
         Method to create a project
         :param project_name: (required | str) Name of project to be created.
@@ -42,7 +44,7 @@ class OcpProjects(OcpBase):
             self.label_a_project(project_name, labels_dict)
         return api_response
 
-    def create_a_namespace(self, namespace_name, labels_dict=None):
+    def create_a_namespace(self, namespace_name: str, labels_dict: Optional[dict] = None) -> Optional[ResourceInstance]:
         """
         Method to create a project/namespace with "openshift" in the beginning of the name.
         :param namespace_name: (required | str) Name of project to be created.
@@ -60,7 +62,7 @@ class OcpProjects(OcpBase):
             self.label_a_project(namespace_name, labels_dict)
         return api_response
 
-    def label_a_project(self, project_name, labels_dict):
+    def label_a_project(self, project_name: str, labels_dict: dict) -> Optional[ResourceInstance]:
         """
         Method that patches a project with user
         defined labels
@@ -76,7 +78,7 @@ class OcpProjects(OcpBase):
             logger.error("Exception when calling method label_a_project: %s\n" % e.reason)
         return api_response
 
-    def get_a_project(self, project_name):
+    def get_a_project(self, project_name: str) -> Optional[ResourceInstance]:
         """
         Method that returns a project by name.
         :param project_name: (required | str) Name of the project to be patched.
@@ -89,7 +91,7 @@ class OcpProjects(OcpBase):
             logger.error("Exception when calling method get_a_project: %s\n" % e.reason)
         return api_response
 
-    def delete_a_project(self, project_name):
+    def delete_a_project(self, project_name: str) -> Optional[ResourceInstance]:
         """
         Method that deletes a project by name.
         :param project_name: (required | str) Name of the project to be deleted.
@@ -104,7 +106,7 @@ class OcpProjects(OcpBase):
             logger.error("Exception when calling method delete_a_project: %s\n" % e.reason)
         return api_response
 
-    def delete_a_namespace(self, namespace_name):
+    def delete_a_namespace(self, namespace_name: str) -> Optional[ResourceInstance]:
         """
         Method that deletes a project by name.
         :param namespace_name: (required | str) Name of the namespace to be deleted.
@@ -119,7 +121,7 @@ class OcpProjects(OcpBase):
             logger.error("Exception when calling method delete_a_namespace: %s\n" % e.reason)
         return api_response
 
-    def delete_labelled_projects(self, label_name):
+    def delete_labelled_projects(self, label_name: str) -> list:
         """
         Method that deletes all projects with the specified label.
         :param label_name: (required | str) label of the projects to be deleted.
@@ -136,10 +138,10 @@ class OcpProjects(OcpBase):
                 logger.error("Exception when calling method delete_labelled_projects: %s\n" % e)
         return deleted_projects
 
-    def get_labelled_projects(self, label_selector):
+    def get_labelled_projects(self, label_selector: str) -> Optional[ResourceInstance]:
         """
         Method that returns all projects with a label selector.
-        :param : label_selector
+        :param label_selector: (required | str) label for the projects to be fetched.
         :return: An object of type V1NamespaceList
         """
         api_response = None
@@ -149,7 +151,7 @@ class OcpProjects(OcpBase):
             logger.error("Exception when calling method get_labelled_projects: %s\n" % e)
         return api_response
 
-    def get_all_projects(self):
+    def get_all_projects(self) -> Optional[ResourceInstance]:
         """
         Method that returns all projects in a cluster.
         :param : None
@@ -162,21 +164,20 @@ class OcpProjects(OcpBase):
             logger.error("Exception when calling method get_all_projects: %s\n" % e.reason)
         return api_response
 
-    def does_project_exist(self, project_name):
+    def does_project_exist(self, project_name: str) -> bool:
         """
         Determine if the specified project exists.
-        :param project_name:
+        :param project_name: (required | str) Name of project to be checked.
         :return: True if the project is found. False if the project is not found.
         """
         has_project = self.get_a_project(project_name)
         return bool(has_project)
 
-    def _watch_is_project_created(self, project_name):
+    def _watch_is_project_created(self, project_name: str) -> bool:
         """
         Provide a watch mechanism to follow project create operations.
 
-        :param: project_name:
-        :param: timeout: The timeout (in seconds) passed to the watch().
+        :param: project_name: (required | str) Name of project to be checked.
         :return: True if the project is Created, False if the project is not found or the
                  state cannot be determined.
         """
@@ -187,12 +188,11 @@ class OcpProjects(OcpBase):
                 return True
         return False
 
-    def _watch_is_project_deleted(self, project_name):
+    def _watch_is_project_deleted(self, project_name: str) -> bool:
         """
         Provide a watch mechanism to follow project delete operations.
 
-        :param: project_name:
-        :param: timeout: The timeout (in seconds) passed to the watch().
+        :param: project_name: (required | str) Name of project to be checked.
         :return: True if the project has been deleted, False if the project is not found.
         """
         field_selector = "status.phase=Terminating"

--- a/piqe_ocp_lib/api/resources/ocp_projects.py
+++ b/piqe_ocp_lib/api/resources/ocp_projects.py
@@ -119,6 +119,36 @@ class OcpProjects(OcpBase):
             logger.error("Exception when calling method delete_a_namespace: %s\n" % e.reason)
         return api_response
 
+    def delete_labelled_projects(self, label_name):
+        """
+        Method that deletes all projects with the specified label.
+        :param label_name: (required | str) label of the projects to be deleted.
+        :return: A list containing objects of type V1Namespace
+        """
+        deleted_projects = []
+        labelled_projects = self.get_labelled_projects(label_selector=label_name)
+        for project in labelled_projects.items:
+            try:
+                api_response = self.ocp_projects.delete(name=project.metadata.name)
+                if self._watch_is_project_deleted(project.metadata.name):
+                    deleted_projects.append(api_response)
+            except ApiException as e:
+                logger.error("Exception when calling method delete_labelled_projects: %s\n" % e)
+        return deleted_projects
+
+    def get_labelled_projects(self, label_selector):
+        """
+        Method that returns all projects with a label selector.
+        :param : label_selector
+        :return: An object of type V1NamespaceList
+        """
+        api_response = None
+        try:
+            api_response = self.ocp_projects.get(label_selector=label_selector)
+        except ApiException as e:
+            logger.error("Exception when calling method get_labelled_projects: %s\n" % e)
+        return api_response
+
     def get_all_projects(self):
         """
         Method that returns all projects in a cluster.

--- a/piqe_ocp_lib/tests/conftest.py
+++ b/piqe_ocp_lib/tests/conftest.py
@@ -9,6 +9,7 @@ import pytest
 
 from piqe_ocp_lib import __loggername__
 from piqe_ocp_lib.api.resources.ocp_cluster_operators import OcpClusterOperator
+from piqe_ocp_lib.api.resources.ocp_projects import OcpProjects
 from piqe_ocp_lib.piqe_api_logger import piqe_api_logger
 
 
@@ -234,3 +235,11 @@ def log_start_test_case(request):
 def setup_logger():
     logger = piqe_api_logger(__loggername__)
     return logger
+
+
+@pytest.fixture(scope="session", autouse=True)
+def delete_css_tagged_projects():
+    """ Fixture to delete all projects with the 'css-test:True' label """
+    yield
+    project_api_obj = OcpProjects()
+    project_api_obj.delete_labelled_projects(label_name="css-test=True")

--- a/piqe_ocp_lib/tests/resources/test_ocp_apps.py
+++ b/piqe_ocp_lib/tests/resources/test_ocp_apps.py
@@ -14,6 +14,7 @@ def setup_params(get_kubeconfig):
     params_dict["project_api_obj"] = OcpProjects(kube_config_file=get_kubeconfig)
     params_dict["template_api_obj"] = OcpTemplates(kube_config_file=get_kubeconfig)
     params_dict["test_project"] = "app-project"
+    params_dict["test_project_labels"] = {"css-test": "True"}
     params_dict["ident"] = randint(0, 10)
     params_dict["test_app_params"] = {"MEMORY_LIMIT": "768Mi"}
     params_dict["template_name"] = "httpd-example"
@@ -37,7 +38,7 @@ class TestOcpApps:
         app_api_obj = setup_params["app_api_obj"]
         project_api_obj = setup_params["project_api_obj"]
         template_api_obj = setup_params["template_api_obj"]
-        project_api_obj.create_a_project(setup_params["test_project"])
+        project_api_obj.create_a_project(setup_params["test_project"], labels_dict=setup_params["test_project_labels"])
         with open("piqe_ocp_lib/tests/resources/templates/httpd.json") as t:
             body = json.load(t)
         template_api_obj.create_a_template_in_a_namespace(body, project=setup_params["test_project"])

--- a/piqe_ocp_lib/tests/resources/test_ocp_operators.py
+++ b/piqe_ocp_lib/tests/resources/test_ocp_operators.py
@@ -228,7 +228,7 @@ class TestSubscription:
     def test_create_subscription(self, get_test_objects):
         # Create a subscription and check kind and name
         # for correctness
-        get_test_objects.project_obj.create_a_project("test-project1")
+        get_test_objects.project_obj.create_a_project("test-project1", labels_dict={"css-test": "True"})
         nfd_default_channel = get_test_objects.op_hub_obj.get_package_default_channel("nfd")
         sub_resp_obj = get_test_objects.sub_obj.create_subscription("nfd", nfd_default_channel, "test-project1")
         assert sub_resp_obj.kind == "Subscription" and sub_resp_obj.metadata.name == "nfd"
@@ -255,8 +255,8 @@ class TestOperatorGroup:
     def test_create_operator_group(self, get_test_objects):
         # Create an operator group and check kind and name
         # for correctness
-        get_test_objects.project_obj.create_a_project("og-project")
-        get_test_objects.project_obj.create_a_project("test-project2")
+        get_test_objects.project_obj.create_a_project("og-project", labels_dict={"css-test": "True"})
+        get_test_objects.project_obj.create_a_project("test-project2", labels_dict={"css-test": "True"})
         og_resp_obj = get_test_objects.og_obj.create_operator_group("test-og", "og-project", ["test-project2"])
         assert og_resp_obj.kind == "OperatorGroup" and og_resp_obj.metadata.name == "test-og"
 
@@ -298,7 +298,7 @@ class TestClusterServiceVersion:
         # We obtain the CSV name from the subscription response object.
         # Finally we check kind and name for correctness and proceed with
         # cleaning up test artifacts.
-        get_test_objects.project_obj.create_a_project("test-project3")
+        get_test_objects.project_obj.create_a_project("test-project3", labels_dict={"css-test": "True"})
         # os_resp_obj = get_test_objects.os_obj.get_operator_source('community-operators')
         get_test_objects.og_obj.create_operator_group("test-og", "openshift-marketplace", ["test-project3"])
         get_test_objects.sub_obj.create_subscription("kong", "SingleNamespace", "openshift-marketplace")
@@ -364,7 +364,7 @@ class TestInstallOperatorWorkflow:
         project_resource.delete_a_project("test-ownnamespace")
 
     def test_add_operator_singlenamespace(self, project_resource, operator_installer, operator_hub, cluster_service):
-        project_resource.create_a_project("test-project4")
+        project_resource.create_a_project("test-project4", labels_dict={"css-test": "True"})
         operator_installer.add_operator_to_cluster(
             "amq-streams", "stable", "test-singlenamespace", target_namespaces=["test-project4"]
         )
@@ -375,8 +375,8 @@ class TestInstallOperatorWorkflow:
         project_resource.delete_a_project("test-project4")
 
     def test_add_operator_multinamespace(self, project_resource, operator_installer, operator_hub, cluster_service):
-        project_resource.create_a_project("test-project5")
-        project_resource.create_a_project("test-project6")
+        project_resource.create_a_project("test-project5", labels_dict={"css-test": "True"})
+        project_resource.create_a_project("test-project6", labels_dict={"css-test": "True"})
         operator_installer.add_operator_to_cluster(
             "amq-streams", "stable", "test-multinamespace", target_namespaces=["test-project5", "test-project6"]
         )

--- a/piqe_ocp_lib/tests/resources/test_ocp_projects.py
+++ b/piqe_ocp_lib/tests/resources/test_ocp_projects.py
@@ -12,10 +12,10 @@ logger = logging.getLogger(__loggername__)
 def setup_params(get_kubeconfig):
     params_dict = {
         "project_api_obj": OcpProjects(kube_config_file=get_kubeconfig),
-        "project1": {"name": "test-project1", "label": {"test": "1"}},
-        "project2": {"name": "test-project2", "label": {"test": "2"}},
-        "project3": {"name": "openshift-test1", "label": {"test": "3"}},
-        "project4": {"name": "openshift-test2", "label": {"test": "4"}},
+        "project1": {"name": "test-project1", "label": {"test": "1", "css-test": "True"}},
+        "project2": {"name": "test-project2", "label": {"test": "2", "css-test": "True"}},
+        "project3": {"name": "openshift-test1", "label": {"test": "3", "css-test": "True"}},
+        "project4": {"name": "openshift-test2", "label": {"test": "4", "css-test": "True"}},
     }
     return params_dict
 
@@ -31,7 +31,9 @@ class TestOcpProjects:
            active phase.
         """
         project_api_obj = setup_params["project_api_obj"]
-        api_response = project_api_obj.create_a_project(setup_params["project1"]["name"])
+        api_response = project_api_obj.create_a_project(
+            setup_params["project1"]["name"], labels_dict=setup_params["project1"]["label"]
+        )
         assert api_response.kind == "Project"
         assert api_response.metadata.name == setup_params["project1"]["name"]
         assert api_response.status["phase"] == "Active"
@@ -46,7 +48,9 @@ class TestOcpProjects:
            active phase.
         """
         project_api_obj = setup_params["project_api_obj"]
-        api_response = project_api_obj.create_a_namespace(namespace_name=setup_params["project3"]["name"])
+        api_response = project_api_obj.create_a_namespace(
+            namespace_name=setup_params["project3"]["name"], labels_dict=setup_params["project3"]["label"]
+        )
         logger.info("API Response : %s", api_response)
         assert api_response.kind == "Namespace"
         assert api_response.metadata.name == setup_params["project3"]["name"]
@@ -169,7 +173,9 @@ class TestOcpProjects:
         api_response = project_api_obj.get_all_projects()
         original_project_count = len(api_response.items)
 
-        create_project_response = project_api_obj.create_a_project(setup_params["project1"]["name"])
+        create_project_response = project_api_obj.create_a_project(
+            setup_params["project1"]["name"], labels_dict=setup_params["project1"]["label"]
+        )
         assert create_project_response.status.phase == "Active"
 
         updated_api_response = project_api_obj.get_all_projects()
@@ -193,7 +199,8 @@ class TestOcpProjects:
         project_api_obj = setup_params["project_api_obj"]
 
         project_name = setup_params["project1"]["name"]
-        project_api_obj.create_a_project(project_name=project_name)
+        project_label = setup_params["project1"]["label"]
+        project_api_obj.create_a_project(project_name=project_name, labels_dict=project_label)
         is_created_project_present = project_api_obj.does_project_exist(project_name)
         assert is_created_project_present is True
 

--- a/piqe_ocp_lib/tests/resources/test_ocp_services.py
+++ b/piqe_ocp_lib/tests/resources/test_ocp_services.py
@@ -37,7 +37,8 @@ def httpd_template() -> str:
 @pytest.fixture
 def project(ocp_project) -> str:
     project_name = "test-services"
-    ocp_project.create_a_project(project_name)
+    project_label = {"css-test": "True"}
+    ocp_project.create_a_project(project_name=project_name, labels_dict=project_label)
 
     yield project_name
 

--- a/piqe_ocp_lib/tests/resources/test_ocp_templates.py
+++ b/piqe_ocp_lib/tests/resources/test_ocp_templates.py
@@ -14,6 +14,7 @@ logger = logging.getLogger(__loggername__)
 def setup_params(get_kubeconfig):
     params_dict = {}
     params_dict["test_project"] = "template-project"
+    params_dict["project_label"] = {"css-test": "True"}
     params_dict["project_api_obj"] = OcpProjects(kube_config_file=get_kubeconfig)
     params_dict["template_api_obj"] = OcpTemplates(kube_config_file=get_kubeconfig)
     params_dict["ident"] = randint(0, 10)
@@ -29,7 +30,9 @@ class TestOcpTemplates:
         :return:
         """
         project_api_obj = setup_params["project_api_obj"]
-        api_response = project_api_obj.create_a_project(setup_params["test_project"])
+        api_response = project_api_obj.create_a_project(
+            setup_params["test_project"], labels_dict=setup_params["project_label"]
+        )
         assert api_response.metadata.name == setup_params["test_project"]
         logger.info(f"Project : {api_response.metadata.name}, succesfully created")
 


### PR DESCRIPTION
I have added a label `"css-test=True"` to projects being created by the tests. 
A global fixture runs at end of each test run (single fn/module or all tests) to delete projects with that label. I have also added 2 functions & corresponding tests to delete/get labelled projects

Some points to discuss:
- Any improvements to the code,solution
- Should the label be hard-coded as such
- Are the functions `delete_labelled_projects`, `get_labelled_projects` & their tests necessary
- Todo:  I haven't yet added labels to projects created in `populate_ocp_cluster`, `test_add_operator_clusterwide` or other places which create namespaces/projects in background/automatically